### PR TITLE
Add ad-keytab, update Wallet::Config

### DIFF
--- a/contrib/ad-keytab
+++ b/contrib/ad-keytab
@@ -1,0 +1,610 @@
+#!/usr/bin/perl -w
+#
+# Create, update, delete, and display keytabs stored in Active Directory.
+#
+# Written by Bill MacAllister <whm@dropbox.com>
+# Copyright 2016 Dropbox, Inc.
+#
+# See LICENSE for licensing terms.
+
+##############################################################################
+# Declarations
+##############################################################################
+
+use Authen::SASL;
+use Carp;
+use Getopt::Long;
+use IPC::Run qw( run timeout );
+use Net::LDAP;
+use Pod::Usage;
+use strict;
+
+my $opt_ad_server;
+my $opt_base_dn;
+my $opt_computer_rdn;
+my $opt_config;
+my $opt_debug;
+my $opt_dump;
+my $opt_help;
+my $opt_manual;
+my $opt_realm;
+my $opt_user_rdn;
+
+# Configuration variables
+our $AD_DEBUG;
+our $AD_SERVER;
+our $AD_COMPUTER_RDN;
+our $AD_USER_RDN;
+our $KEYTAB_REALM;
+our $AD_BASE_DN;
+
+##############################################################################
+# Subroutines
+##############################################################################
+
+# Write messages to standard output and check the return status
+sub msg {
+    my @msgs = @_;
+    for my $m (@msgs) {
+        print STDOUT $m . "\n" or croak("Problem printing to STDOUT");
+    }
+    return;
+}
+
+# Write debugging messages
+sub dbg {
+    my ($m) = @_;
+    msg("DEBUG:$m");
+    return;
+}
+
+# Decode Active Directory's userAccountControl attribute
+# Flags are powers of two starting at zero.
+sub list_userAccountControl {
+    my ($uac) = @_;
+    my @flags = (
+        'SCRIPT',
+        'ACCOUNTDISABLE',
+        'HOMEDIR_REQUIRED',
+        'LOCKOUT',
+        'PASSWD_NOTREQD',
+        'PASSWD_CANT_CHANGE',
+        'ENCRYPTED_TEXT_PWD_ALLOWED',
+        'TEMP_DUPLICATE_ACCOUNT',
+        'NORMAL_ACCOUNT',
+        'INTERDOMAIN_TRUST_ACCOUNT',
+        'WORKSTATION_TRUST_ACCOUNT',
+        'SERVER_TRUST_ACCOUNT',
+        'DONT_EXPIRE_PASSWORD',
+        'MNS_LOGON_ACCOUNT',
+        'SMARTCARD_REQUIRED',
+        'TRUSTED_FOR_DELEGATION',
+        'NOT_DELEGATED',
+        'USE_DES_KEY_ONLY',
+        'DONT_REQ_PREAUTH',
+        'PASSWORD_EXPIRED',
+        'TRUSTED_TO_AUTH_FOR_DELEGATION',
+        'PARTIAL_SECRETS_ACCOUNT'
+    );
+
+    my $flag_list;
+    my $comma = '';
+    for (my $i=0; $i<scalar(@flags); $i++) {
+        if ($uac & (2**$i)) {
+            $flag_list .= $comma . $flags[$i];
+            $comma = ', ';
+        }
+    }
+    return $flag_list;
+}
+
+# GSS-API bind to the active directory server
+sub ldap_connect {
+    my $ldap;
+    if ($AD_DEBUG) {
+        dbg('binding to ' . $AD_SERVER);
+    }
+    if (!$AD_SERVER) {
+        croak("Missing ldap host name, specify ad_server=\n");
+    }
+    eval {
+        my $sasl = Authen::SASL->new(mechanism => 'GSSAPI');
+        $ldap = Net::LDAP->new($AD_SERVER, onerror => 'die');
+        my $mesg = eval { $ldap->bind(undef, sasl => $sasl) };
+    };
+    if ($@) {
+        my $error = $@;
+        die "ldap bind to AD failed: $error\n";
+    }
+    return $ldap;
+}
+
+# Take a principal and split into parts.  The parts are keytab type,
+# keytab identifier, the base dn, an LDAP filter, and if the keytab
+# type is host the host name.
+sub kerberos_attrs {
+    my ($principal) = @_;
+
+    my %attr = ();
+    my $dn;
+    my $host;
+    my $k_type;
+    my $k_id;
+    if ($principal =~ m,^(host|service)/(\S+),xms) {
+        $attr{type} = $1;
+        $attr{id}   = $2;
+        if ($attr{type} eq 'host') {
+            $attr{base}   = $AD_COMPUTER_RDN . ',' . $AD_BASE_DN;
+            $attr{host}   = $attr{id};
+            $attr{host}   =~ s/[.].*//;
+            $attr{dn}     = "cn=$attr{host},$attr{base}";
+            $attr{filter} = "(samAccountName=$attr{host}\$)";
+        } elsif ($attr{'type'} eq 'service') {
+            $attr{base}   = $AD_USER_RDN  . ',' . $AD_BASE_DN;
+            $attr{dn}     = "cn=srv-$attr{id},$attr{base}";
+            $attr{filter} = "(servicePrincipalName=$attr{type}/$attr{id})";
+        }
+    }
+    if ($AD_DEBUG) {
+        for my $a (sort keys %attr) {
+            dbg("$a = $attr{$a}");
+        }
+    }
+    return %attr;
+}
+
+# Perform an LDAP search against AD and return information about
+# service and host accounts.
+sub ad_show {
+    my ($principal, $kattr_ref) = @_;
+
+    my $ldap = ldap_connect();
+    my %kattr = %{$kattr_ref};
+    my $base   = $kattr{base};
+    my $filter = $kattr{filter};
+    my @attrs = ();
+    if (!$opt_dump) {
+        @attrs = (
+            'distinguishedName',             'objectclass',
+            'dnsHostname',                   'msds-KeyVersionNumber',
+            'msds-SupportedEncryptionTypes', 'name',
+            'servicePrincipalName',          'samAccountName',
+            'userAccountControl',            'userPrincipalName',
+            'whenChanged',                   'whenCreated',
+            );
+    }
+
+    if ($AD_DEBUG) {
+        dbg("base:$base filter:$filter scope:subtree\n");
+    }
+
+    my $result;
+    eval {
+        $result = $ldap->search(
+            base   => $base,
+            scope  => 'subtree',
+            filter => $filter,
+            attrs  => \@attrs
+            );
+    };
+    if ($@) {
+        my $error = $@;
+        die "LDAP search error: $error\n";
+    }
+    if ($result->code) {
+        msg("INFO base:$base filter:$filter scope:subtree\n");
+        die $result->error;
+    }
+    if ($AD_DEBUG) {
+        dbg('returned: ' . $result->count);
+    }
+    if ($result->count > 0) {
+        for my $entry ($result->entries) {
+            for my $attr ( sort $entry->attributes ) {
+                my $out = '';
+                if ($attr =~ /userAccountControl/xmsi) {
+                    my $val = $entry->get_value($attr);
+                    $out = "$attr: $val";
+                    $out .= ' (' . list_userAccountControl($val) . ')';
+                    msg($out);
+                } else {
+                    my $val_ref = $entry->get_value($attr, asref => 1);
+                    my @vals = @{$val_ref};
+                    for my $val (@vals) {
+                        msg("$attr: $val");
+                    }
+                }
+            }
+        }
+    } else {
+        msg("$kattr{type}/$kattr{id} not found");
+    }
+    msg(' ');
+    return;
+}
+
+# Check to see if a keytab exists
+sub ad_exists {
+    my ($principal, $kattr_ref) = @_;
+
+    my $ldap = ldap_connect();
+    my %kattr = %{$kattr_ref};
+    my $base   = $kattr{base};
+    my $filter = $kattr{filter};
+    my @attrs = ('objectClass', 'msds-KeyVersionNumber');
+    if ($AD_DEBUG) {
+        dbg("base:$base filter:$filter scope:subtree\n");
+    }
+
+    my $result;
+    eval {
+        $result = $ldap->search(
+            base   => $base,
+            scope  => 'subtree',
+            filter => $filter,
+            attrs  => \@attrs
+            );
+    };
+    if ($@) {
+        my $error = $@;
+        die "LDAP search error: $error\n";
+    }
+    if ($result->code) {
+        msg("INFO base:$base filter:$filter scope:subtree\n");
+        die $result->error;
+    }
+    if ($AD_DEBUG) {
+        dbg('returned: ' . $result->count);
+    }
+    if ($result->count > 1) {
+        msg('ERROR: too many AD entries for this keytab');
+        for my $entry ($result->entries) {
+            msg('INFO: dn found ' . $entry->dn . "\n");
+        }
+        die("INFO: use show to examine the problem\n");
+    }
+    if ($result->count) {
+        for my $entry ($result->entries) {
+            return $entry->get_value('msds-KeyVersionNumber');
+        }
+    } else {
+        return 0;
+    }
+    return;
+}
+
+# Run a shell command.  In this case the command will always be msktutil.
+sub run_cmd {
+    my @cmd = @_;
+
+    if ($AD_DEBUG) {
+        dbg('running command:' . join(q{ }, @cmd));
+    }
+
+    my $in;
+    my $out;
+    my $err;
+    my $err_flag;
+    eval {
+        run(\@cmd, \$in, \$out, \$err, timeout(60));
+        if ($?) {
+            my $this_err = $?;
+            $err_flag = 1;
+            if ($this_err) {
+                msg('ERROR:' . $?);
+            }
+            if ($err) {
+                msg('ERROR (err):' . $err);
+            }
+        }
+    };
+    if ($@) {
+        msg('ERROR (status):' . $@);
+        $err_flag = 1;
+    }
+    if ($err_flag) {
+        msg('ERROR: Problem executing:' . join(q{ }, @cmd));
+        die "FATAL: Execution failed\n";
+    }
+
+    msg($out);
+    return;
+}
+
+# Either create or update a keytab for the principal.  Return the name
+# of the keytab file created.
+sub ad_create_update {
+    my ($principal, $file, $action) = @_;
+    my @cmd = ('/usr/sbin/msktutil');
+    push @cmd, '--' . $action;
+    push @cmd, '--server',   $AD_SERVER;
+    push @cmd, '--enctypes', '0x4';
+    push @cmd, '--enctypes', '0x8';
+    push @cmd, '--enctypes', '0x10';
+    push @cmd, '--keytab',   $file;
+    if ($KEYTAB_REALM) {
+        push @cmd, '--realm', $KEYTAB_REALM;
+    }
+    if ($principal =~ m,^host/(\S+),xms) {
+        my $fqdn = $1;
+        my $host = $fqdn;
+        $host =~ s/[.].*//xms;
+        push @cmd, '--base', $AD_COMPUTER_RDN;
+        push @cmd, '--dont-expire-password';
+        push @cmd, '--computer-name', $host;
+        push @cmd, '--upn',           "host/$fqdn";
+        push @cmd, '--hostname',      $fqdn;
+    } elsif ($principal =~ m,^service/(\S+),xms) {
+        my $service_id = $1;
+        push @cmd, '--base', $AD_USER_RDN;
+        push @cmd, '--use-service-account';
+        push @cmd, '--service',      "service/$service_id";
+        push @cmd, '--account-name', "srv-${service_id}";
+        push @cmd, '--no-pac';
+    }
+    run_cmd(@cmd);
+    return;
+}
+
+# Delete a principal from Kerberos.  For AD this means just delete the
+# object using LDAP.
+sub ad_delete {
+    my ($principal, $kattr_ref) = @_;
+
+    my %kattr = %{$kattr_ref};
+    if (!ad_exists($principal, $kattr_ref)) {
+        msg("WARN: the keytab for $principal does not appear to exist.");
+        msg("INFO: attempting the delete anyway.\n");
+    }
+
+    my $ldap = ldap_connect();
+    my $msgid = $ldap->delete($kattr{dn});
+    if ($msgid->code) {
+        my $m;
+        $m .= "ERROR: Problem deleting $kattr{dn}\n";
+        $m .= $msgid->error;
+        die $m;
+    }
+    return 1;
+}
+
+##############################################################################
+# Main Routine
+##############################################################################
+
+# Get options
+GetOptions(
+    'ad_server=s'    => \$opt_ad_server,
+    'base_dn=s'      => \$opt_base_dn,
+    'computer_rdn=s' => \$opt_computer_rdn,
+    'config=s'       => \$opt_config,
+    'debug'          => \$opt_debug,
+    'dump'           => \$opt_dump,
+    'help'           => \$opt_help,
+    'manual'         => \$opt_manual,
+    'realm'          => \$opt_realm,
+    'user_rdn=s'     => \$opt_user_rdn
+);
+
+# Help the user
+if ($opt_manual) {
+    pod2usage(-verbose => 2);
+}
+if ($opt_help || !$ARGV[0]) {
+    pod2usage(-verbose => 0);
+}
+
+# Make sure that we have kerberos credentials and that KRB5CCNAME
+# points to them.
+if (!$ENV{'KRB5CCNAME'}) {
+    msg('ERROR: Kerberos credentials are required ... try kinit');
+    pod2usage(-verbose => 0);
+}
+
+# Read the configuration file or croak
+my $conf_file;
+if ($opt_config) {
+    if (-e $opt_config) {
+        $conf_file = $opt_config;
+    } else {
+        msg("ERROR: Config file ($opt_config) not found");
+        pod2usage(-verbose => 0);
+    }
+} elsif ($ENV{'ADKEYTAB'}) {
+    $conf_file = $ENV{'ADKEYTAB'};
+} elsif (-e '.ad-keytab.conf') {
+    $conf_file = '.ad-keytab.conf';
+} else {
+    $conf_file = '/etc/wallet/wallet.conf';
+}
+do $conf_file or die (($@ || $!) . "\n");
+
+# Process command line options
+if ($opt_ad_server) {
+    $AD_SERVER = $opt_ad_server;
+}
+if ($opt_base_dn) {
+    $AD_BASE_DN = $opt_base_dn;
+}
+if ($opt_computer_rdn) {
+    $AD_COMPUTER_RDN = $opt_computer_rdn;
+}
+if ($opt_user_rdn) {
+    $AD_USER_RDN = $opt_user_rdn;
+}
+if ($opt_debug) {
+    $AD_DEBUG = 1;
+}
+
+# -- Get command line arguments
+my $action = shift;
+my $id     = shift;
+my $keytab;
+if ($ARGV[0]) {
+    $keytab = shift;
+} else {
+    $keytab = '/etc/krb5.keytab';
+}
+
+my %kattr = kerberos_attrs($id);
+# Validate that the keytab id makes sense for the keytab type
+if ($kattr{type} eq 'service') {
+    if ($kattr{id} =~ /[.]/xms) {
+        msg('ERROR: service principal names may not contain periods');
+        pod2usage(-verbose => 0);
+    }
+    if (length($kattr{id}) > 22) {
+        msg('ERROR: service principal name too long');
+        pod2usage(-verbose => 0);
+    }
+} elsif ($kattr{type} eq 'host') {
+    if ($kattr{id} !~ /[.]/xms) {
+        msg('ERROR: FQDN is required');
+        pod2usage(-verbose => 0);
+    }
+} else {
+    msg("ERROR: unknown keytab type $kattr{type}");
+    pod2usage(-verbose => 0);
+}
+
+if ($action =~ /^(create|update)/xms) {
+    ad_create_update($id, $keytab, $1);
+} elsif ($action =~ /^del/xms) {
+    ad_delete($id, \%kattr);
+} elsif ($action =~ /^sh/xms) {
+    ad_show($id, \%kattr);
+} else {
+    msg("ERROR: unknown action $action");
+    pod2usage(-verbose => 0);
+}
+
+exit;
+
+__END__
+
+=head1 NAME
+
+ad-keytab
+
+=head1 SYNOPSIS
+
+ad-keytab create|update|delete|show keytab-id [keytab-file]
+[--ad_server=hostname] [--computer_rdn=dn] [--user_rdn] [--dump]
+[--help] [--manual] [--debug]
+
+=head1 DESCRIPTION
+
+This script is a wrapper around msktutil and ldapsearch to simplify
+the creation of host and service keytabs.  The script is useful for
+boot strapping the kerberos credentials required to use Active
+Directory as a backend keytab store for wallet.  The script shares
+the wallet configuration file.
+
+Generally, two keytabs will need to be created to setup update.  One
+host keytab for the wallet server host and one service keytab for
+wallet to use when connecting to an Active Directory Domain
+Controller.
+
+Note, this script does not update the Wallet database which means
+any keytabs created by it will be invisible from wallet.
+
+=head1 ACTIONS
+
+=over 4
+
+=item create
+
+Add a keytab to AD and update the keytab file.  Fails if the keytab
+already exists.
+
+=item update
+
+Update an existing keytab in AD and update the keytab file.  Fails if
+the keytab does not exist.
+
+=item delete
+
+Delete a keytab from AD and remove it from the keytab file.
+
+=item show
+
+Show AD's view of the account corresponding to the keytab.  This action
+does not use msktutil and queries AD directly using LDAP.
+
+=back
+
+=head1 OPTIONS AND ARGUMENTS
+
+=over 4
+
+=item keytab-id
+
+This is either host principal name of the form host/<fqdn> or a
+service principal name of the form service/<id>.  Service keytab
+identifiers cannot be longer than 18 characters because of an
+ActiveDirectory restriction.
+
+=item keytab-filename
+
+The name of the keytab file.  Defaults to /etc/krb5.keytab.
+
+=item --conf=filename
+
+The configuration file to read.  The script searches for a configuration
+file in the following order.
+
+      * The command line switch --conf
+      * The environment variable ADKEYTAB
+      * The file .ad-keytab.conf
+      * The file /etc/ad-keytab.conf
+
+=item --ad_server=hostname
+
+The name of the Active Directory host to connect to.  It is important
+what the script contact only _one_ server due to the fact that
+propagation within an Active Directory domain can be quite slow.
+
+=item --base_dn=ou=org,dc=domain,dc=tld
+
+The base distinguished name holding both computer and user accounts.
+
+=item --computer_rdn=dn
+
+The relative distinguished name to use as the base DN for both the
+creation of host keytabs and searches of Active Directory.  The
+distinguished name formed will be computer_rdn,base_dn.
+
+=item --user_rdn=dn
+
+The relative distinguished name to use as the base DN for ldap
+searches of Active Directory for service keytabs.  The distinguished
+name formed will be user_rdn_rdn,base_dn.
+
+=item --dump
+
+When displaying keytab attributes show all of the attributes.
+
+=item --help
+
+Displays help text.
+
+=item --manual
+
+Displays more complete help text.
+
+=item --debug
+
+Turns on debugging displays.
+
+=back
+
+=head1 SEE ALSO
+
+Set the documentation for Wallet::Config for configuration information, i.e.
+perldoc Wallet::Config.
+
+=head1 AUTHOR
+
+Bill MacAllister <whm@dropbox.com>
+
+=cut

--- a/contrib/ad-keytab
+++ b/contrib/ad-keytab
@@ -27,16 +27,20 @@ my $opt_debug;
 my $opt_dump;
 my $opt_help;
 my $opt_manual;
-my $opt_realm;
+my $opt_prefix;
 my $opt_user_rdn;
 
+# LDAP conneciton
+my $LDAP;
+
 # Configuration variables
+our $AD_BASE_DN;
+our $AD_COMPUTER_RDN;
 our $AD_DEBUG;
 our $AD_SERVER;
-our $AD_COMPUTER_RDN;
+our $AD_SERVICE_PREFIX;
 our $AD_USER_RDN;
 our $KEYTAB_REALM;
-our $AD_BASE_DN;
 
 ##############################################################################
 # Subroutines
@@ -100,49 +104,147 @@ sub list_userAccountControl {
 
 # GSS-API bind to the active directory server
 sub ldap_connect {
-    my $ldap;
     if ($AD_DEBUG) {
         dbg('binding to ' . $AD_SERVER);
     }
+
+    if ($LDAP) {
+        if ($AD_DEBUG) {
+            dbg('Already bound to ' . $AD_SERVER);
+        }
+        return $LDAP;
+    }
+
     if (!$AD_SERVER) {
         croak("Missing ldap host name, specify ad_server=\n");
     }
     eval {
         my $sasl = Authen::SASL->new(mechanism => 'GSSAPI');
-        $ldap = Net::LDAP->new($AD_SERVER, onerror => 'die');
-        my $mesg = eval { $ldap->bind(undef, sasl => $sasl) };
+        $LDAP = Net::LDAP->new($AD_SERVER, onerror => 'die');
+        my $mesg = eval { $LDAP->bind(undef, sasl => $sasl) };
     };
     if ($@) {
         my $error = $@;
         die "ldap bind to AD failed: $error\n";
     }
-    return $ldap;
+    return $LDAP;
+}
+
+# Take in a base and a filter and return the assoicated DN.
+sub get_dn {
+    my ($base, $filter) = @_;
+    my $dn;
+
+    if ($AD_DEBUG) {
+        dbg("base:$base filter:$filter scope:subtree\n");
+    }
+
+    ldap_connect();
+    my @attrs = ('objectclass');
+    my $result;
+    eval {
+        $result = $LDAP->search(
+            base   => $base,
+            scope  => 'subtree',
+            filter => $filter,
+            attrs  => \@attrs
+            );
+    };
+    if ($@) {
+        my $error = $@;
+        die "LDAP search error: $error\n";
+    }
+    if ($result->code) {
+        msg("INFO base:$base filter:$filter scope:subtree\n");
+        die $result->error;
+    }
+    if ($AD_DEBUG) {
+        dbg('returned: ' . $result->count);
+    }
+
+    if ($result->count == 1) {
+        for my $entry ($result->entries) {
+            $dn = $entry->dn;
+        }
+    } elsif ($result->count > 1) {
+        msg('ERROR: too many AD entries for this keytab');
+        for my $entry ($result->entries) {
+            msg('INFO: dn found ' . $entry->dn . "\n");
+        }
+        die("INFO: use show to examine the problem\n");
+    }
+
+    return $dn;
 }
 
 # Take a principal and split into parts.  The parts are keytab type,
-# keytab identifier, the base dn, an LDAP filter, and if the keytab
-# type is host the host name.
+# keytab identifier, the base dn, the cn, and an LDAP filter.
 sub kerberos_attrs {
     my ($principal) = @_;
 
-    my %attr = ();
+    my %attr;
+    $attr{principal} = $principal;
+
     my $dn;
     my $host;
     my $k_type;
     my $k_id;
-    if ($principal =~ m,^(host|service)/(\S+),xms) {
+    if ($principal =~ m,^(.*?)/(\S+),xms) {
         $attr{type} = $1;
         $attr{id}   = $2;
+        # Create a filter to find the objects we create
+        if ($attr{id} =~ s/@(.*)//xms) {
+            $attr{realm}  = $1;
+            $attr{filter} = "(userPrincipalName=${principal})";
+        } elsif ($KEYTAB_REALM) {
+            $attr{realm} = $KEYTAB_REALM;
+            $attr{filter}
+              = "(userPrincipalName=${principal}\@${KEYTAB_REALM})";
+        } else {
+            $attr{filter} = "(userPrincipalName=${principal}\@*)";
+        }
         if ($attr{type} eq 'host') {
-            $attr{base}   = $AD_COMPUTER_RDN . ',' . $AD_BASE_DN;
-            $attr{host}   = $attr{id};
-            $attr{host}   =~ s/[.].*//;
-            $attr{dn}     = "cn=$attr{host},$attr{base}";
-            $attr{filter} = "(samAccountName=$attr{host}\$)";
-        } elsif ($attr{'type'} eq 'service') {
-            $attr{base}   = $AD_USER_RDN  . ',' . $AD_BASE_DN;
-            $attr{dn}     = "cn=srv-$attr{id},$attr{base}";
-            $attr{filter} = "(servicePrincipalName=$attr{type}/$attr{id})";
+            # Host keytab attributes
+            $attr{base} = $AD_COMPUTER_RDN . ',' . $AD_BASE_DN;
+            $attr{cn}   = $attr{id};
+            $attr{cn}   =~ s/[.].*//;
+            $attr{dn}   = "cn=$attr{cn},$attr{base}";
+        } else {
+            # Service keytab attributes
+            $attr{base} = $AD_USER_RDN  . ',' . $AD_BASE_DN;
+            $attr{cn}   = "${AD_SERVICE_PREFIX}$attr{id}";
+            $attr{dn}   = "cn=$attr{cn},$attr{base}";
+            my $real_dn = get_dn($attr{base}, $attr{filter});
+            if ($real_dn) {
+                if (lc($real_dn) ne lc($attr{dn})) {
+                    $attr{dn} = $real_dn;
+                    $attr{cn} = $real_dn;
+                    $attr{cn} =~ s/,.*//xms;
+                    $attr{cn} =~ s/.*?=//xms;
+                }
+            } else {
+                if (length($attr{cn})>20) {
+                    my $cnt = 0;
+                    my $this_dn;
+                    my $this_prefix = substr($attr{cn}, 0, 18);
+                    $attr{dn} = '';
+                    while ($cnt<100) {
+                        my $this_cn = $this_prefix . sprintf('%02i', $cnt);
+                        $this_dn = get_dn($attr{base}, "cn=$this_cn");
+                        if (!$this_dn) {
+                            $attr{dn} = $this_cn . ',' . $attr{base};
+                            $attr{cn} = $attr{dn};
+                            $attr{cn} =~ s/,.*//xms;
+                            $attr{cn} =~ s/.*?=//xms;
+                            last;
+                        }
+                        $cnt++;
+                    }
+                    if (!$attr{dn}) {
+                        die "ERROR: Cannot file unique dn for keytab\n";
+                    }
+                }
+            }
         }
     }
     if ($AD_DEBUG) {
@@ -158,7 +260,7 @@ sub kerberos_attrs {
 sub ad_show {
     my ($principal, $kattr_ref) = @_;
 
-    my $ldap = ldap_connect();
+    ldap_connect();
     my %kattr = %{$kattr_ref};
     my $base   = $kattr{base};
     my $filter = $kattr{filter};
@@ -180,7 +282,7 @@ sub ad_show {
 
     my $result;
     eval {
-        $result = $ldap->search(
+        $result = $LDAP->search(
             base   => $base,
             scope  => 'subtree',
             filter => $filter,
@@ -220,56 +322,6 @@ sub ad_show {
         msg("$kattr{type}/$kattr{id} not found");
     }
     msg(' ');
-    return;
-}
-
-# Check to see if a keytab exists
-sub ad_exists {
-    my ($principal, $kattr_ref) = @_;
-
-    my $ldap = ldap_connect();
-    my %kattr = %{$kattr_ref};
-    my $base   = $kattr{base};
-    my $filter = $kattr{filter};
-    my @attrs = ('objectClass', 'msds-KeyVersionNumber');
-    if ($AD_DEBUG) {
-        dbg("base:$base filter:$filter scope:subtree\n");
-    }
-
-    my $result;
-    eval {
-        $result = $ldap->search(
-            base   => $base,
-            scope  => 'subtree',
-            filter => $filter,
-            attrs  => \@attrs
-            );
-    };
-    if ($@) {
-        my $error = $@;
-        die "LDAP search error: $error\n";
-    }
-    if ($result->code) {
-        msg("INFO base:$base filter:$filter scope:subtree\n");
-        die $result->error;
-    }
-    if ($AD_DEBUG) {
-        dbg('returned: ' . $result->count);
-    }
-    if ($result->count > 1) {
-        msg('ERROR: too many AD entries for this keytab');
-        for my $entry ($result->entries) {
-            msg('INFO: dn found ' . $entry->dn . "\n");
-        }
-        die("INFO: use show to examine the problem\n");
-    }
-    if ($result->count) {
-        for my $entry ($result->entries) {
-            return $entry->get_value('msds-KeyVersionNumber');
-        }
-    } else {
-        return 0;
-    }
     return;
 }
 
@@ -314,7 +366,9 @@ sub run_cmd {
 # Either create or update a keytab for the principal.  Return the name
 # of the keytab file created.
 sub ad_create_update {
-    my ($principal, $file, $action) = @_;
+    my ($file, $action, $kattr_ref) = @_;
+    my %kattr = %{$kattr_ref};
+
     my @cmd = ('/usr/sbin/msktutil');
     push @cmd, '--' . $action;
     push @cmd, '--server',   $AD_SERVER;
@@ -322,24 +376,21 @@ sub ad_create_update {
     push @cmd, '--enctypes', '0x8';
     push @cmd, '--enctypes', '0x10';
     push @cmd, '--keytab',   $file;
-    if ($KEYTAB_REALM) {
-        push @cmd, '--realm', $KEYTAB_REALM;
+    push @cmd, '--upn',           $kattr{principal};
+    if ($kattr{realm}) {
+        push @cmd, '--realm', $kattr{realm};
     }
-    if ($principal =~ m,^host/(\S+),xms) {
-        my $fqdn = $1;
-        my $host = $fqdn;
-        $host =~ s/[.].*//xms;
+    if ($kattr{type} eq 'host') {
         push @cmd, '--base', $AD_COMPUTER_RDN;
         push @cmd, '--dont-expire-password';
-        push @cmd, '--computer-name', $host;
-        push @cmd, '--upn',           "host/$fqdn";
-        push @cmd, '--hostname',      $fqdn;
-    } elsif ($principal =~ m,^service/(\S+),xms) {
+        push @cmd, '--computer-name', $kattr{cn};
+        push @cmd, '--hostname',      $kattr{id};
+    } else {
         my $service_id = $1;
         push @cmd, '--base', $AD_USER_RDN;
         push @cmd, '--use-service-account';
-        push @cmd, '--service',      "service/$service_id";
-        push @cmd, '--account-name', "srv-${service_id}";
+        push @cmd, '--service',      $kattr{principal};
+        push @cmd, '--account-name', $kattr{cn};
         push @cmd, '--no-pac';
     }
     run_cmd(@cmd);
@@ -349,23 +400,25 @@ sub ad_create_update {
 # Delete a principal from Kerberos.  For AD this means just delete the
 # object using LDAP.
 sub ad_delete {
-    my ($principal, $kattr_ref) = @_;
-
+    my ($kattr_ref) = @_;
     my %kattr = %{$kattr_ref};
-    if (!ad_exists($principal, $kattr_ref)) {
-        msg("WARN: the keytab for $principal does not appear to exist.");
-        msg("INFO: attempting the delete anyway.\n");
-    }
 
-    my $ldap = ldap_connect();
-    my $msgid = $ldap->delete($kattr{dn});
-    if ($msgid->code) {
-        my $m;
-        $m .= "ERROR: Problem deleting $kattr{dn}\n";
-        $m .= $msgid->error;
-        die $m;
+    my $del_dn = get_dn($kattr{base}, $kattr{filter});
+
+    if (!$del_dn) {
+        msg("WARN: the keytab for $kattr{principal} does not exist.");
+        return 1;
+    } else {
+        ldap_connect();
+        my $msgid = $LDAP->delete($del_dn);
+        if ($msgid->code) {
+            my $m;
+            $m .= "ERROR: Problem deleting $kattr{dn}\n";
+            $m .= $msgid->error;
+            die $m;
+        }
     }
-    return 1;
+    return;
 }
 
 ##############################################################################
@@ -381,8 +434,8 @@ GetOptions(
     'debug'          => \$opt_debug,
     'dump'           => \$opt_dump,
     'help'           => \$opt_help,
+    'prefix'         => \$opt_prefix,
     'manual'         => \$opt_manual,
-    'realm'          => \$opt_realm,
     'user_rdn=s'     => \$opt_user_rdn
 );
 
@@ -397,7 +450,8 @@ if ($opt_help || !$ARGV[0]) {
 # Make sure that we have kerberos credentials and that KRB5CCNAME
 # points to them.
 if (!$ENV{'KRB5CCNAME'}) {
-    msg('ERROR: Kerberos credentials are required ... try kinit');
+    msg('INFO: environment variable KRB5CCNAME not found.');
+    msg('ERROR: Kerberos credentials are required.');
     pod2usage(-verbose => 0);
 }
 
@@ -426,6 +480,9 @@ if ($opt_ad_server) {
 if ($opt_base_dn) {
     $AD_BASE_DN = $opt_base_dn;
 }
+if ($opt_prefix) {
+    $AD_SERVICE_PREFIX = $opt_prefix;
+}
 if ($opt_computer_rdn) {
     $AD_COMPUTER_RDN = $opt_computer_rdn;
 }
@@ -448,29 +505,22 @@ if ($ARGV[0]) {
 
 my %kattr = kerberos_attrs($id);
 # Validate that the keytab id makes sense for the keytab type
-if ($kattr{type} eq 'service') {
-    if ($kattr{id} =~ /[.]/xms) {
-        msg('ERROR: service principal names may not contain periods');
-        pod2usage(-verbose => 0);
-    }
-    if (length($kattr{id}) > 22) {
-        msg('ERROR: service principal name too long');
-        pod2usage(-verbose => 0);
-    }
-} elsif ($kattr{type} eq 'host') {
+if ($kattr{type} eq 'host') {
     if ($kattr{id} !~ /[.]/xms) {
         msg('ERROR: FQDN is required');
         pod2usage(-verbose => 0);
     }
 } else {
-    msg("ERROR: unknown keytab type $kattr{type}");
-    pod2usage(-verbose => 0);
+    if ($kattr{id} =~ /[.]/xms) {
+        msg('ERROR: service principal names may not contain periods');
+        pod2usage(-verbose => 0);
+    }
 }
 
 if ($action =~ /^(create|update)/xms) {
-    ad_create_update($id, $keytab, $1);
+    ad_create_update($keytab, $action, \%kattr);
 } elsif ($action =~ /^del/xms) {
-    ad_delete($id, \%kattr);
+    ad_delete(\%kattr);
 } elsif ($action =~ /^sh/xms) {
     ad_show($id, \%kattr);
 } else {
@@ -500,7 +550,7 @@ boot strapping the kerberos credentials required to use Active
 Directory as a backend keytab store for wallet.  The script shares
 the wallet configuration file.
 
-Generally, two keytabs will need to be created to setup update.  One
+Generally, two keytabs will need to be created to setup wallet.  One
 host keytab for the wallet server host and one service keytab for
 wallet to use when connecting to an Active Directory Domain
 Controller.

--- a/perl/lib/Wallet/Config.pm
+++ b/perl/lib/Wallet/Config.pm
@@ -463,10 +463,22 @@ default PATH.
 
 our $AD_MSKTUTIL = 'msktutil';
 
+=item AD_SERVICE_LENGTH
+
+The maximum length of a unique identifier, samAccountName, for Active
+Directory keytab objects.  If the indentifier exceeds this length then
+it will be trunciated and an integer will be appended to the end of
+the identifier.  This parameter is here in hopes that at some point
+in the future Microsoft will remove the limitation.
+
+=cut
+
+our $AD_SERVICE_LENGTH = '20';
+
 =item AD_SERVICE_LIMIT
 
 Used to limit the number of iterations used in attempting to find a
-unique account name for service principals.  Defaults to 999.
+unique account name for principals.  Defaults to 999.
 
 =cut
 

--- a/perl/lib/Wallet/Config.pm
+++ b/perl/lib/Wallet/Config.pm
@@ -415,40 +415,39 @@ our $KEYTAB_TMP;
 
 =back
 
-The following parameters are specific to generating keytabs from Active
-Directory (KEYTAB_KRBTYPE is set to C<AD>).
+The following parameters are specific to generating keytabs from
+Active Directory (KEYTAB_KRBTYPE is set to C<AD>).
 
 =over 4
 
-=item AD_CACHE
+=item AD_BASE_DN
 
-Specifies the ticket cache to use when manipulating Active Directory objects.
-The ticket cache must be for a principal able to bind to Active Directory and
-run B<msktutil>.
-
-AD_CACHE must be set to use Active Directory support.
+The base distinguished name of the ActiveDirectory instance.  This is
+use when Wallet uses LDAP directly to examine objects in Active
+Directory.
 
 =cut
 
-our $AD_CACHE;
+our $AD_BASE_DN;
 
-=item AD_COMPUTER_DN
+=item AD_COMPUTER_RDN
 
-The LDAP base DN for computer objects inside Active Directory.  All keytabs of
-the form host/<hostname> will be mapped to objects with a C<samAccountName> of
-the <hostname> portion under this DN.
+The LDAP base DN for computer objects inside Active Directory.  All
+keytabs of the form host/<hostname> will be mapped to objects with a
+C<samAccountName> of the <hostname> portion under this DN.
 
-AD_COMPUTER_DN must be set if using Active Directory as the keytab backend.
+AD_COMPUTER_RDN must be set if using Active Directory as the keytab
+backend.
 
 =cut
 
-our $AD_COMPUTER_DN;
+our $AD_COMPUTER_RDN;
 
 =item AD_DEBUG
 
-If set to true, asks for some additional debugging information, such as the
-B<msktutil> command, to be logged to syslog.  These debugging messages will be
-logged to the C<local3> facility.
+If set to true, asks for some additional debugging information, such
+as the B<msktutil> command, to be logged to syslog.  These debugging
+messages will be logged to the C<local3> facility.
 
 =cut
 
@@ -464,17 +463,25 @@ default PATH.
 
 our $AD_MSKTUTIL = 'msktutil';
 
-=item AD_USER_DN
+=item AD_SERVER
+
+The hostname of the Active Directory Domain Controller.
+
+=cut
+
+our $AD_SERVER;
+
+=item AD_USER_RDN
 
 The LDAP base DN for user objects inside Active Directory.  All keytabs of the
 form service/<user> will be mapped to objects with a C<servicePrincipalName>
 matching the wallet object name under this DN.
 
-AD_USER_DN must be set if using Active Directory as the keytab backend.
+AD_USER_RDN must be set if using Active Directory as the keytab backend.
 
 =cut
 
-our $AD_USER_DN;
+our $AD_USER_RDN;
 
 =back
 
@@ -482,14 +489,20 @@ our $AD_USER_DN;
 
 Heimdal provides the choice, over the network protocol, of either
 downloading the existing keys for a principal or generating new random
-keys.  MIT Kerberos does not; downloading a keytab over the kadmin
-protocol always rekeys the principal.
+keys.  Neither MIT Kerberos or ActiveDirectory support retrieving an
+existing keytab; downloading a keytab over the kadmin protocol or
+using msktutil always rekeys the principal.
 
 For MIT Kerberos, the keytab object backend therefore optionally supports
 retrieving existing keys, and hence keytabs, for Kerberos principals by
 contacting the KDC via remctl and talking to B<keytab-backend>.  This is
 enabled by setting the C<unchanging> flag on keytab objects.  To configure
 that support, set the following variables.
+
+For ActiveDirectory Kerberos, the keytab object backend supports
+storing the keytabs on the wallet server.  This functionality is
+enabled by setting the configuration variable AD_KEYTAB_BUCKET.  (This
+had not been implemented yet.)
 
 This is not required for Heimdal; for Heimdal, setting the C<unchanging>
 flag is all that's needed.
@@ -541,6 +554,25 @@ will be used.
 =cut
 
 our $KEYTAB_REMCTL_PORT;
+
+=item AD_CACHE
+
+The ticket cache that hold credentials used to access the
+ActiveDirectory KDC.  This must be created and maintained externally.
+
+=cut
+
+our $AD_CACHE;
+
+=item AD_KEYTAB_BUCKET
+
+The path to store a copy of keytabs created.  This is required for the
+support of unchanging keytabs with an ActiveDirectory KDC.  (This has
+not been implemented yet.)
+
+=cut
+
+our $AD_KEYTAB_BUCKET = '/var/lib/wallet/keytabs';
 
 =back
 

--- a/perl/lib/Wallet/Config.pm
+++ b/perl/lib/Wallet/Config.pm
@@ -463,6 +463,33 @@ default PATH.
 
 our $AD_MSKTUTIL = 'msktutil';
 
+=item AD_SERVICE_LIMIT
+
+Used to limit the number of iterations used in attempting to find a
+unique account name for service principals.  Defaults to 999.
+
+=cut
+
+our $AD_SERVICE_LIMIT = '999';
+
+=item AD_SERVICE_PREFIX
+
+For service principals the AD_SERVICE_PREFIX will be combined with the
+principal identifier to form the account name, i.e. the CN, used to
+store the keytab entry in the Active Directory.  Active Directory
+limits these CN's to a maximum of 20 characters.  If the resulting CN
+is greater than 20 characters the CN will be truncated and an integer
+will be appended to it.  The integer will be incremented until a
+unique CN is found.
+
+The AD_SERVICE_PREFIX is generally useful only prevent name collisions
+when the service keytabs are store in branch of the DIT that also
+contains other similar objects.
+
+=cut
+
+our $AD_SERVICE_PREFIX;
+
 =item AD_SERVER
 
 The hostname of the Active Directory Domain Controller.

--- a/perl/lib/Wallet/Kadmin/AD.pm
+++ b/perl/lib/Wallet/Kadmin/AD.pm
@@ -280,8 +280,8 @@ sub get_service_id {
             my $this_prefix = substr($this_cn, 0, 20-$suffix_size);
             my $this_format = "%0${suffix_size}i";
             while ($cnt<$loop_limit) {
-                my $this_cn = $this_prefix . sprintf($this_format, $cnt);
-                $this_dn = ldap_get_dn($this_base, "cn=$this_cn");
+                $this_cn = $this_prefix . sprintf($this_format, $cnt);
+                $this_dn = $self->ldap_get_dn($this_base, "cn=$this_cn");
                 if (!$this_dn) {
                     $this_id = $this_cn;
                     last;

--- a/perl/lib/Wallet/Kadmin/AD.pm
+++ b/perl/lib/Wallet/Kadmin/AD.pm
@@ -1,8 +1,8 @@
 # Wallet::Kadmin::AD -- Wallet Kerberos administration API for AD
 #
-# Written by Bill MacAllister <bill@ca-zephyr.org>
+# Written by Bill MacAllister <whm@dropbox.com>
 # Copyright 2016 Russ Allbery <eagle@eyrie.org>
-# Copyright 2015 Dropbox, Inc.
+# Copyright 2015,2016 Dropbox, Inc.
 # Copyright 2007, 2008, 2009, 2010, 2014
 #     The Board of Trustees of the Leland Stanford Junior University
 #
@@ -100,17 +100,19 @@ sub ldap_base_filter {
         my $fqdn = $1;
         my $host = $fqdn;
         $host =~ s/[.].*//xms;
-        $base   = $Wallet::Config::AD_COMPUTER_DN;
         $filter = "(samAccountName=${host}\$)";
+        $base   = $Wallet::Config::AD_COMPUTER_RDN . ','
+          . $Wallet::Config::AD_BASE_DN;
     } elsif ($principal =~ m,^service/(\S+),xms) {
         my $id = $1;
-        $base   = $Wallet::Config::AD_USER_DN;
         $filter = "(servicePrincipalName=service/${id})";
+        $base
+          = $Wallet::Config::AD_USER_RDN . ',' . $Wallet::Config::AD_BASE_DN;
     }
     return ($base, $filter);
 }
 
-# TODO: Get a keytab from the keytab cache.
+# TODO: Get a keytab from the keytab bucket.
 sub get_ad_keytab {
     my ($self, $principal) = @_;
     return;
@@ -125,13 +127,16 @@ sub get_ad_keytab {
 sub msktutil {
     my ($self, $args_ref) = @_;
     unless (defined($Wallet::Config::KEYTAB_HOST)
+        and defined($Wallet::Config::KEYTAB_PRINCIPAL)
+        and defined($Wallet::Config::KEYTAB_FILE)
         and defined($Wallet::Config::KEYTAB_REALM))
     {
         die "keytab object implementation not configured\n";
     }
-    unless (defined($Wallet::Config::AD_CACHE)
-        and defined($Wallet::Config::AD_COMPUTER_DN)
-        and defined($Wallet::Config::AD_USER_DN))
+    unless (-e $Wallet::Config::AD_MSKTUTIL
+        and defined($Wallet::Config::AD_BASE_DN)
+        and defined($Wallet::Config::AD_COMPUTER_RDN)
+        and defined($Wallet::Config::AD_USER_RDN))
     {
         die "Active Directory support not configured\n";
     }
@@ -194,14 +199,16 @@ sub ad_create_update {
         my $fqdn = $1;
         my $host = $fqdn;
         $host =~ s/[.].*//xms;
+        push @cmd, '--base',          $Wallet::Config::COMPUTER_RDN;
         push @cmd, '--dont-expire-password';
         push @cmd, '--computer-name', $host;
-        push @cmd, '--upn', "host/$fqdn";
-        push @cmd, '--hostname', $fqdn;
+        push @cmd, '--upn',           "host/$fqdn";
+        push @cmd, '--hostname',      $fqdn;
     } elsif ($principal =~ m,^service/(\S+),xms) {
         my $service_id = $1;
+        push @cmd, '--base',         $Wallet::Config::USER_RDN;
         push @cmd, '--use-service-account';
-        push @cmd, '--service', "service/$service_id";
+        push @cmd, '--service',      "service/$service_id";
         push @cmd, '--account-name', "srv-${service_id}";
         push @cmd, '--no-pac';
     }
@@ -367,9 +374,15 @@ sub ad_delete {
         if ($k_type eq 'host') {
             my $host = $k_id;
             $host =~ s/[.].*//;
-            $dn = "cn=${host}," . $Wallet::Config::AD_COMPUTER_DN;
+            $dn
+              = "cn=${host},"
+              . $Wallet::Config::AD_COMPUTER_RDN . ','
+              . $Wallet::Config::AD_BASE_DN;
         } elsif ($k_type eq 'service') {
-            $dn = "cn=srv-${k_id}," . $Wallet::Config::AD_USER_DN;
+            $dn
+              = "cn=srv-${k_id},"
+              . $Wallet::Config::AD_USER_RDN . ','
+              . $Wallet::Config::AD_BASE_DN;
         }
     }
 
@@ -436,18 +449,6 @@ using a local keytab cache.
 
 To use this class, several configuration parameters must be set.  See
 L<Wallet::Config/"KEYTAB OBJECT CONFIGURATION"> for details.
-
-=head1 FILES
-
-=over 4
-
-=item KEYTAB_TMP/keytab.<pid>
-
-The keytab is created in this file and then read into memory.  KEYTAB_TMP
-is set in the wallet configuration, and <pid> is the process ID of the
-current process.  The file is unlinked after being read.
-
-=back
 
 =head1 LIMITATIONS
 

--- a/perl/lib/Wallet/Kadmin/AD.pm
+++ b/perl/lib/Wallet/Kadmin/AD.pm
@@ -44,6 +44,27 @@ sub ad_debug {
     return;
 }
 
+# Return a string given an array whose elements are command line arguments
+# passws to IPC::Run.  Quote any strings that have embedded spaces.  Replace
+# null elements with the string #NULL#.
+
+sub ad_cmd_string {
+    my ($self, $cmd_ref) = @_;
+    my $z  = '';
+    my $ws = ' ';
+    for my $e (@{ $cmd_ref }) {
+        if (!$e) {
+            $z .= $ws . '#NULL#';
+        } elsif ($e =~ /\s/xms) {
+            $z .= $ws . '"' . $e . '"';
+        } else {
+            $z .= $ws . $e;
+        }
+        $ws = ' ';
+    }
+    return $z;
+}
+
 # Make sure that principals are well-formed and don't contain
 # characters that will cause us problems when talking to kadmin.
 # Takes a principal and returns true if it's okay, false otherwise.
@@ -144,7 +165,7 @@ sub msktutil {
     my @cmd  = ($Wallet::Config::AD_MSKTUTIL);
     push @cmd, @args;
     if ($Wallet::Config::AD_DEBUG) {
-        $self->ad_debug('debug', join(' ', @cmd));
+        $self->ad_debug('debug', $self->ad_cmd_string(\@cmd));
     }
 
     my $in;
@@ -199,14 +220,14 @@ sub ad_create_update {
         my $fqdn = $1;
         my $host = $fqdn;
         $host =~ s/[.].*//xms;
-        push @cmd, '--base',          $Wallet::Config::COMPUTER_RDN;
+        push @cmd, '--base',          $Wallet::Config::AD_COMPUTER_RDN;
         push @cmd, '--dont-expire-password';
         push @cmd, '--computer-name', $host;
         push @cmd, '--upn',           "host/$fqdn";
         push @cmd, '--hostname',      $fqdn;
     } elsif ($principal =~ m,^service/(\S+),xms) {
         my $service_id = $1;
-        push @cmd, '--base',         $Wallet::Config::USER_RDN;
+        push @cmd, '--base',         $Wallet::Config::AD_USER_RDN;
         push @cmd, '--use-service-account';
         push @cmd, '--service',      "service/$service_id";
         push @cmd, '--account-name', "srv-${service_id}";

--- a/perl/lib/Wallet/Kadmin/AD.pm
+++ b/perl/lib/Wallet/Kadmin/AD.pm
@@ -272,15 +272,21 @@ sub get_account_id {
         $this_id =~ s/.*?=//xms;
     } else {
         my ($this_type, $this_cn) = split '/', $this_princ, 2;
-        if ($Wallet::Config::AD_SERVICE_PREFIX && $this_type = 'service') {
-            $this_cn = $Wallet::Config::AD_SERVICE_PREFIX . $this_cn;
+        my $max_len;
+        if ($this_type eq 'host') {
+            $max_len = $Wallet::Config::AD_SERVICE_LENGTH - 1;
+        } else {
+            $max_len = $Wallet::Config::AD_SERVICE_LENGTH;
+            if ($Wallet::Config::AD_SERVICE_PREFIX) {
+                $this_cn = $Wallet::Config::AD_SERVICE_PREFIX . $this_cn;
+            }
         }
         my $loop_limit = $Wallet::Config::AD_SERVICE_LIMIT;
-        if (length($this_cn)>20) {
+        if (length($this_cn)>$max_len) {
             my $cnt = 0;
             my $this_dn;
             my $suffix_size = length("$loop_limit");
-            my $this_prefix = substr($this_cn, 0, 20-$suffix_size);
+            my $this_prefix = substr($this_cn, 0, $max_len - $suffix_size);
             my $this_format = "%0${suffix_size}i";
             while ($cnt<$loop_limit) {
                 $this_cn = $this_prefix . sprintf($this_format, $cnt);

--- a/perl/lib/Wallet/Kadmin/AD.pm
+++ b/perl/lib/Wallet/Kadmin/AD.pm
@@ -36,11 +36,14 @@ my $LDAP;
 
 # Send debugging output to syslog.
 
-sub ad_debug {
+sub ad_syslog {
     my ($self, $l, $m) = @_;
     if (!$self->{SYSLOG}) {
         openlog('wallet-server', 'ndelay,nofatal', 'local3');
         $self->{SYSLOG} = 1;
+    }
+    if ($l !~ /debug|info|err|warning/xms) {
+        $l = 'err';
     }
     syslog($l, $m);
     return;
@@ -145,7 +148,7 @@ sub ldap_get_dn {
     my $dn;
 
     if ($Wallet::Config::AD_DEBUG) {
-        $self->ad_debug('debug', "base:$base filter:$filter scope:subtree\n");
+        $self->ad_syslog('debug', "base:$base filter:$filter scope:subtree\n");
     }
 
     $self->ldap_connect();
@@ -164,11 +167,11 @@ sub ldap_get_dn {
         die "LDAP search error: $error\n";
     }
     if ($result->code) {
-        msg("INFO base:$base filter:$filter scope:subtree\n");
+        $self->ad_syslog('info', "base:$base filter:$filter scope:subtree\n");
         die $result->error;
     }
     if ($Wallet::Config::AD_DEBUG) {
-        $self->ad_debug('debug', 'returned: ' . $result->count);
+        $self->ad_syslog('debug', 'returned: ' . $result->count);
     }
 
     if ($result->count == 1) {
@@ -176,9 +179,9 @@ sub ldap_get_dn {
             $dn = $entry->dn;
         }
     } elsif ($result->count > 1) {
-        msg('ERROR: too many AD entries for this keytab');
+        $self->ad_syslog('err', 'too many AD entries for this keytab');
         for my $entry ($result->entries) {
-            msg('INFO: dn found ' . $entry->dn . "\n");
+            $self->ad_syslog('info', 'dn found: ' . $entry->dn . "\n");
         }
         die("INFO: use show to examine the problem\n");
     }
@@ -218,7 +221,7 @@ sub msktutil {
     my @cmd  = ($Wallet::Config::AD_MSKTUTIL);
     push @cmd, @args;
     if ($Wallet::Config::AD_DEBUG) {
-        $self->ad_debug('debug', $self->ad_cmd_string(\@cmd));
+        $self->ad_syslog('debug', $self->ad_cmd_string(\@cmd));
     }
 
     my $in;
@@ -241,6 +244,7 @@ sub msktutil {
             $err_msg .= "ERROR: $err\n";
             $err_msg .= 'Problem command: ' . join(' ', @cmd) . "\n";
         }
+        $self->ad_syslog('err', $err_msg);
         die $err_msg;
     } else {
         if ($err) {
@@ -248,7 +252,7 @@ sub msktutil {
         }
     }
     if ($Wallet::Config::AD_DEBUG) {
-        $self->ad_debug('debug', $out);
+        $self->ad_syslog('debug', $out);
     }
     return $out;
 }
@@ -267,8 +271,7 @@ sub get_service_id {
         $this_id =~ s/,.*//xms;
         $this_id =~ s/.*?=//xms;
     } else {
-        my $this_cn = $this_princ;
-        $this_cn =~ s{.*?/}{}xms;
+        my ($this_type, $this_cn) = split '/', $this_princ, 2;
         if ($Wallet::Config::AD_SERVICE_PREFIX) {
             $this_cn = $Wallet::Config::AD_SERVICE_PREFIX . $this_cn;
         }
@@ -326,7 +329,7 @@ sub ad_create_update {
             push @cmd, '--computer-name', $host;
             push @cmd, '--hostname',      $this_id;
         } else {
-            my $service_id = $self->get_service_id($this_id);
+            my $service_id = $self->get_service_id($principal);
             push @cmd, '--base',         $Wallet::Config::AD_USER_RDN;
             push @cmd, '--use-service-account';
             push @cmd, '--service',      $principal;
@@ -339,9 +342,9 @@ sub ad_create_update {
         {
             $self->ad_delete($principal);
             my $m = "ERROR: problem creating keytab for $principal";
-            $self->ad_debug('error', $m);
-            $self->ad_debug('error',
-                            'Problem command:' . ad_cmd_string(\@cmd));
+            $self->ad_syslog('error', $m);
+            $self->ad_syslog('error',
+                             'Problem command:' . ad_cmd_string(\@cmd));
             die "$m\n";
         }
     } else {
@@ -385,7 +388,7 @@ sub create {
     }
     if ($self->exists($principal)) {
         if ($Wallet::Config::AD_DEBUG) {
-            $self->ad_debug('debug', "$principal exists");
+            $self->ad_syslog('debug', "$principal exists");
         }
         return 1;
     }
@@ -465,6 +468,7 @@ sub ad_delete {
         my $m;
         $m .= "ERROR: Problem deleting $dn\n";
         $m .= $msgid->error;
+        $self->ad_syslog('err', $m);
         die $m;
     }
     return 1;

--- a/perl/lib/Wallet/Kadmin/AD.pm
+++ b/perl/lib/Wallet/Kadmin/AD.pm
@@ -28,6 +28,8 @@ use Wallet::Kadmin;
 our @ISA     = qw(Wallet::Kadmin);
 our $VERSION = '1.04';
 
+my $LDAP;
+
 ##############################################################################
 # kadmin Interaction
 ##############################################################################
@@ -71,17 +73,7 @@ sub ad_cmd_string {
 # Note that we do not permit realm information here.
 sub valid_principal {
     my ($self, $principal) = @_;
-    my $valid = 0;
-    if ($principal =~ m,^(host|service)(/[\w_.-]+)?\z,) {
-        my $k_type = $1;
-        my $k_id   = $2;
-        if ($k_type eq 'host') {
-            $valid = 1 if $k_id =~ m/[.]/xms;
-        } elsif ($k_type eq 'service') {
-            $valid = 1 if length($k_id) < 19;
-        }
-    }
-    return $valid;
+    return scalar ($principal =~ m,^[\w-]+(/[\w_.-]+)?\z,);
 }
 
 # Connect to the Active Directory server using LDAP. The connection is
@@ -90,47 +82,108 @@ sub valid_principal {
 sub ldap_connect {
     my ($self) = @_;
 
-    if (!-e $Wallet::Config::AD_CACHE) {
-        die 'Missing kerberos ticket cache ' . $Wallet::Config::AD_CACHE;
+    if (!$LDAP) {
+        eval {
+            local $ENV{KRB5CCNAME} = $Wallet::Config::AD_CACHE;
+            my $sasl = Authen::SASL->new(mechanism => 'GSSAPI');
+            $LDAP = Net::LDAP->new($Wallet::Config::KEYTAB_HOST,
+                                   onerror => 'die');
+            my $mesg = eval { $LDAP->bind(undef, sasl => $sasl) };
+        };
+        if ($@) {
+            my $error = $@;
+            chomp $error;
+            1 while ($error =~ s/ at \S+ line \d+\.?\z//);
+            die "LDAP bind to AD failed: $error\n";
+        }
     }
-
-    my $ldap;
-    eval {
-        local $ENV{KRB5CCNAME} = $Wallet::Config::AD_CACHE;
-        my $sasl = Authen::SASL->new(mechanism => 'GSSAPI');
-        $ldap = Net::LDAP->new($Wallet::Config::KEYTAB_HOST, onerror => 'die');
-        my $mesg = eval { $ldap->bind(undef, sasl => $sasl) };
-    };
-    if ($@) {
-        my $error = $@;
-        chomp $error;
-        1 while ($error =~ s/ at \S+ line \d+\.?\z//);
-        die "LDAP bind to AD failed: $error\n";
-    }
-
-    return $ldap;
+    return $LDAP;
 }
 
 # Construct a base filter for searching Active Directory.
 
 sub ldap_base_filter {
     my ($self, $principal) = @_;
+
     my $base;
     my $filter;
-    if ($principal =~ m,^host/(\S+),xms) {
-        my $fqdn = $1;
-        my $host = $fqdn;
-        $host =~ s/[.].*//xms;
-        $filter = "(samAccountName=${host}\$)";
-        $base   = $Wallet::Config::AD_COMPUTER_RDN . ','
-          . $Wallet::Config::AD_BASE_DN;
-    } elsif ($principal =~ m,^service/(\S+),xms) {
-        my $id = $1;
-        $filter = "(servicePrincipalName=service/${id})";
-        $base
-          = $Wallet::Config::AD_USER_RDN . ',' . $Wallet::Config::AD_BASE_DN;
+    my $this_type;
+    my $this_id;
+
+    if ($principal =~ m,^(.*?)/(\S+),xms) {
+        $this_type = $1;
+        $this_id   = $2;
+    } else {
+        $this_id = $principal;
     }
+
+    # Create a filter to find the objects we create
+    if ($this_id =~ s/@(.*)//xms) {
+        $filter = "(userPrincipalName=${principal})";
+    } elsif ($Wallet::Config::KEYTAB_REALM) {
+        $filter = '(userPrincipalName=' . $principal
+        . '@' . $Wallet::Config::KEYTAB_REALM . ')';
+    } else {
+        $filter = "(userPrincipalName=${principal}\@*)";
+    }
+
+    # Set the base distinguished name
+    if ($this_type && $this_type eq 'host') {
+        $base = $Wallet::Config::AD_COMPUTER_RDN;
+    } else {
+        $base = $Wallet::Config::AD_USER_RDN;
+    }
+    $base .= ',' . $Wallet::Config::AD_BASE_DN;
+
     return ($base, $filter);
+}
+
+# Take in a base and a filter and return the assoicated DN or return
+# null if there is no matching entry.
+sub ldap_get_dn {
+    my ($self, $base, $filter) = @_;
+    my $dn;
+
+    if ($Wallet::Config::AD_DEBUG) {
+        $self->ad_debug('debug', "base:$base filter:$filter scope:subtree\n");
+    }
+
+    $self->ldap_connect();
+    my @attrs = ('objectclass');
+    my $result;
+    eval {
+        $result = $LDAP->search(
+            base   => $base,
+            scope  => 'subtree',
+            filter => $filter,
+            attrs  => \@attrs
+            );
+    };
+    if ($@) {
+        my $error = $@;
+        die "LDAP search error: $error\n";
+    }
+    if ($result->code) {
+        msg("INFO base:$base filter:$filter scope:subtree\n");
+        die $result->error;
+    }
+    if ($Wallet::Config::AD_DEBUG) {
+        $self->ad_debug('debug', 'returned: ' . $result->count);
+    }
+
+    if ($result->count == 1) {
+        for my $entry ($result->entries) {
+            $dn = $entry->dn;
+        }
+    } elsif ($result->count > 1) {
+        msg('ERROR: too many AD entries for this keytab');
+        for my $entry ($result->entries) {
+            msg('INFO: dn found ' . $entry->dn . "\n");
+        }
+        die("INFO: use show to examine the problem\n");
+    }
+
+    return $dn;
 }
 
 # TODO: Get a keytab from the keytab bucket.
@@ -200,10 +253,53 @@ sub msktutil {
     return $out;
 }
 
+# The unique identifier that Active Directory used to store keytabs
+# has a maximum length of 20 characters.  This routine takes a
+# principal name an generates a unique ID based on the principal name.
+sub get_service_id {
+    my ($self, $this_princ) = @_;
+
+    my $this_id;
+    my ($this_base, $this_filter) = $self->ldap_base_filter($this_princ);
+    my $real_dn = $self->ldap_get_dn($this_base, $this_filter);
+    if ($real_dn) {
+        $this_id = $real_dn;
+        $this_id =~ s/,.*//xms;
+        $this_id =~ s/.*?=//xms;
+    } else {
+        my $this_cn = $this_princ;
+        $this_cn =~ s{.*?/}{}xms;
+        if ($Wallet::Config::AD_SERVICE_PREFIX) {
+            $this_cn = $Wallet::Config::AD_SERVICE_PREFIX . $this_cn;
+        }
+        my $loop_limit = $Wallet::Config::AD_SERVICE_LIMIT;
+        if (length($this_cn)>20) {
+            my $cnt = 0;
+            my $this_dn;
+            my $suffix_size = length("$loop_limit");
+            my $this_prefix = substr($this_cn, 0, 20-$suffix_size);
+            my $this_format = "%0${suffix_size}i";
+            while ($cnt<$loop_limit) {
+                my $this_cn = $this_prefix . sprintf($this_format, $cnt);
+                $this_dn = ldap_get_dn($this_base, "cn=$this_cn");
+                if (!$this_dn) {
+                    $this_id = $this_cn;
+                    last;
+                }
+                $cnt++;
+            }
+        } else {
+            $this_id = $this_cn;
+        }
+    }
+    return $this_id;
+}
+
 # Either create or update a keytab for the principal.  Return the
 # name of the keytab file created.
 sub ad_create_update {
     my ($self, $principal, $action) = @_;
+    return unless $self->valid_principal($principal);
     my $keytab = $Wallet::Config::KEYTAB_TMP . "/keytab.$$";
     if (-e $keytab) {
         unlink $keytab or die "Problem deleting $keytab\n";
@@ -215,31 +311,41 @@ sub ad_create_update {
     push @cmd, '--enctypes', '0x10';
     push @cmd, '--keytab',   $keytab;
     push @cmd, '--realm',    $Wallet::Config::KEYTAB_REALM;
+    push @cmd, '--upn',      $principal;
 
-    if ($principal =~ m,^host/(\S+),xms) {
-        my $fqdn = $1;
-        my $host = $fqdn;
-        $host =~ s/[.].*//xms;
-        push @cmd, '--base',          $Wallet::Config::AD_COMPUTER_RDN;
-        push @cmd, '--dont-expire-password';
-        push @cmd, '--computer-name', $host;
-        push @cmd, '--upn',           "host/$fqdn";
-        push @cmd, '--hostname',      $fqdn;
-    } elsif ($principal =~ m,^service/(\S+),xms) {
-        my $service_id = $1;
-        push @cmd, '--base',         $Wallet::Config::AD_USER_RDN;
-        push @cmd, '--use-service-account';
-        push @cmd, '--service',      "service/$service_id";
-        push @cmd, '--account-name', "srv-${service_id}";
-        push @cmd, '--no-pac';
-    }
-    my $out = $self->msktutil(\@cmd);
-    if ($out =~ /Error:\s+\S+\s+failed/xms) {
-        $self->ad_delete($principal);
-        my $m = "ERROR: problem creating keytab:\n" . $out;
-        $m .= 'INFO: the keytab used to by wallet probably has'
-          . " insufficient access to AD\n";
-        die $m;
+    my $this_type;
+    my $this_id;
+    if ($principal =~ m,^(.*?)/(\S+),xms) {
+        $this_type = $1;
+        $this_id   = $2;
+        if ($this_type eq 'host') {
+            my $host = $this_id;
+            $host =~ s/[.].*//xms;
+            push @cmd, '--base',          $Wallet::Config::AD_COMPUTER_RDN;
+            push @cmd, '--dont-expire-password';
+            push @cmd, '--computer-name', $host;
+            push @cmd, '--hostname',      $this_id;
+        } else {
+            my $service_id = $self->get_service_id($this_id);
+            push @cmd, '--base',         $Wallet::Config::AD_USER_RDN;
+            push @cmd, '--use-service-account';
+            push @cmd, '--service',      $principal;
+            push @cmd, '--account-name', $service_id;
+            push @cmd, '--no-pac';
+        }
+        my $out = $self->msktutil(\@cmd);
+        if ($out =~ /Error:\s+\S+\s+failed/xms
+            || !$self->exists($principal))
+        {
+            $self->ad_delete($principal);
+            my $m = "ERROR: problem creating keytab for $principal";
+            $self->ad_debug('error', $m);
+            $self->ad_debug('error',
+                            'Problem command:' . ad_cmd_string(\@cmd));
+            die "$m\n";
+        }
+    } else {
+        die "ERROR: Invalid principal format ($principal)\n";
     }
 
     return $keytab;
@@ -262,45 +368,9 @@ sub exists {
     my ($self, $principal) = @_;
     return unless $self->valid_principal($principal);
 
-    my $ldap = $self->ldap_connect();
     my ($base, $filter) = $self->ldap_base_filter($principal);
-    my @attrs = ('objectClass', 'msds-KeyVersionNumber');
 
-    my $result;
-    eval {
-        $result = $ldap->search(
-            base   => $base,
-            scope  => 'subtree',
-            filter => $filter,
-            attrs  => \@attrs
-        );
-    };
-
-    if ($@) {
-        my $error = $@;
-        die "LDAP search error: $error\n";
-    }
-    if ($result->code) {
-        my $m;
-        $m .= "INFO base:$base filter:$filter scope:subtree\n";
-        $m .= 'ERROR:' . $result->error . "\n";
-        die $m;
-    }
-    if ($result->count > 1) {
-        my $m = "ERROR: too many AD entries for this keytab\n";
-        for my $entry ($result->entries) {
-            $m .= 'INFO: dn found ' . $entry->dn . "\n";
-        }
-        die $m;
-    }
-    if ($result->count) {
-        for my $entry ($result->entries) {
-            return $entry->get_value('msds-KeyVersionNumber');
-        }
-    } else {
-        return 0;
-    }
-    return;
+    return $self->ldap_get_dn($base, $filter);
 }
 
 # Call msktutil to Create a principal in Kerberos.  Sets the error and
@@ -373,7 +443,7 @@ sub destroy {
     }
     my $exists = $self->exists($principal);
     if (!defined $exists) {
-        return;
+        return 1;
     } elsif (not $exists) {
         return 1;
     }
@@ -386,29 +456,11 @@ sub destroy {
 sub ad_delete {
     my ($self, $principal) = @_;
 
-    my $k_type;
-    my $k_id;
-    my $dn;
-    if ($principal =~ m,^(host|service)/(\S+),xms) {
-        $k_type = $1;
-        $k_id   = $2;
-        if ($k_type eq 'host') {
-            my $host = $k_id;
-            $host =~ s/[.].*//;
-            $dn
-              = "cn=${host},"
-              . $Wallet::Config::AD_COMPUTER_RDN . ','
-              . $Wallet::Config::AD_BASE_DN;
-        } elsif ($k_type eq 'service') {
-            $dn
-              = "cn=srv-${k_id},"
-              . $Wallet::Config::AD_USER_RDN . ','
-              . $Wallet::Config::AD_BASE_DN;
-        }
-    }
+    my ($base, $filter) = $self->ldap_base_filter($principal);
+    my $dn = $self->ldap_get_dn($base, $filter);
 
-    my $ldap  = $self->ldap_connect();
-    my $msgid = $ldap->delete($dn);
+    $self->ldap_connect();
+    my $msgid = $LDAP->delete($dn);
     if ($msgid->code) {
         my $m;
         $m .= "ERROR: Problem deleting $dn\n";

--- a/perl/lib/Wallet/Kadmin/AD.pm
+++ b/perl/lib/Wallet/Kadmin/AD.pm
@@ -42,7 +42,7 @@ sub ad_syslog {
         openlog('wallet-server', 'ndelay,nofatal', 'local3');
         $self->{SYSLOG} = 1;
     }
-    if ($l !~ /debug|info|err|warning/xms) {
+    if ($l !~ /^(debug|info|err|warning/xms)$) {
         $l = 'err';
     }
     syslog($l, $m);
@@ -348,8 +348,8 @@ sub ad_create_update {
         {
             $self->ad_delete($principal);
             my $m = "ERROR: problem creating keytab for $principal";
-            $self->ad_syslog('error', $m);
-            $self->ad_syslog('error',
+            $self->ad_syslog('err', $m);
+            $self->ad_syslog('err',
                              'Problem command:' . ad_cmd_string(\@cmd));
             die "$m\n";
         }

--- a/perl/lib/Wallet/Kadmin/AD.pm
+++ b/perl/lib/Wallet/Kadmin/AD.pm
@@ -260,7 +260,7 @@ sub msktutil {
 # The unique identifier that Active Directory used to store keytabs
 # has a maximum length of 20 characters.  This routine takes a
 # principal name an generates a unique ID based on the principal name.
-sub get_service_id {
+sub get_account_id {
     my ($self, $this_princ) = @_;
 
     my $this_id;
@@ -272,7 +272,7 @@ sub get_service_id {
         $this_id =~ s/.*?=//xms;
     } else {
         my ($this_type, $this_cn) = split '/', $this_princ, 2;
-        if ($Wallet::Config::AD_SERVICE_PREFIX) {
+        if ($Wallet::Config::AD_SERVICE_PREFIX && $this_type = 'service') {
             $this_cn = $Wallet::Config::AD_SERVICE_PREFIX . $this_cn;
         }
         my $loop_limit = $Wallet::Config::AD_SERVICE_LIMIT;
@@ -321,19 +321,19 @@ sub ad_create_update {
     if ($principal =~ m,^(.*?)/(\S+),xms) {
         $this_type = $1;
         $this_id   = $2;
+        my $account_id = $self->get_account_id($principal);
         if ($this_type eq 'host') {
             my $host = $this_id;
             $host =~ s/[.].*//xms;
             push @cmd, '--base',          $Wallet::Config::AD_COMPUTER_RDN;
             push @cmd, '--dont-expire-password';
-            push @cmd, '--computer-name', $host;
+            push @cmd, '--computer-name', $account_id;
             push @cmd, '--hostname',      $this_id;
         } else {
-            my $service_id = $self->get_service_id($principal);
             push @cmd, '--base',         $Wallet::Config::AD_USER_RDN;
             push @cmd, '--use-service-account';
             push @cmd, '--service',      $principal;
-            push @cmd, '--account-name', $service_id;
+            push @cmd, '--account-name', $account_id;
             push @cmd, '--no-pac';
         }
         my $out = $self->msktutil(\@cmd);


### PR DESCRIPTION
- The ad-keytab script is useful in the initial setup of AD as a keytab
  store for wallet.
- Change configuration variables to correctly reflect that some values
  are relative distinguished names.
- Add a configuration variable for the base distinguished name for
  ActiveDirectory.
