### PR TITLE
AD support bug fixes

### DIFF
--- a/contrib/ad-keytab
+++ b/contrib/ad-keytab
@@ -1,0 +1,674 @@
+#!/usr/bin/perl
+#
+# Create, update, delete, and display keytabs stored in Active Directory.
+
+##############################################################################
+# Declarations
+##############################################################################
+
+use AppConfig qw(:argcount :expand);
+use Authen::SASL;
+use Carp;
+use Getopt::Long;
+use IPC::Run qw( run timeout );
+use Net::LDAP;
+use Pod::Usage;
+use strict;
+
+my $opt_ad_server;
+my $opt_base_dn;
+my $opt_computer_rdn;
+my $opt_config;
+my $opt_debug;
+my $opt_dump;
+my $opt_example;
+my $opt_help;
+my $opt_manual;
+my $opt_realm;
+my $opt_user_rdn;
+
+my $CONF;
+
+##############################################################################
+# Subroutines
+##############################################################################
+
+# Write messages to standard output and check the return status
+sub msg {
+    my @msgs = @_;
+    for my $m (@msgs) {
+        print STDOUT $m . "\n" or croak("Problem printing to STDOUT");
+    }
+    return;
+}
+
+# Write debugging messages
+sub dbg {
+    my ($m) = @_;
+    msg("DEBUG:$m");
+    return;
+}
+
+# Read values from the configuration file if one exists
+sub read_config {
+    my ($conf_file) = @_;
+
+    $CONF = AppConfig->new({});
+    $CONF->define(
+        'ad_server',
+        {
+            DEFAULT  => 'ad.microsoft.com',
+            ARGCOUNT => ARGCOUNT_ONE
+        }
+    );
+    $CONF->define(
+        'base_dn',
+        {
+            DEFAULT  => 'OU=MICROSOFT,DC=MICROSOFT,DC=COM',
+            ARGCOUNT => ARGCOUNT_ONE
+        }
+    );
+    $CONF->define(
+        'computer_rdn',
+        {
+            DEFAULT  => 'OU=Computers',
+            ARGCOUNT => ARGCOUNT_ONE
+        }
+    );
+    $CONF->define('realm', { ARGCOUNT => ARGCOUNT_ONE });
+    $CONF->define(
+        'user_rdn',
+        {
+            DEFAULT  => 'OU=Users',
+            ARGCOUNT => ARGCOUNT_ONE
+        }
+    );
+    $CONF->define(
+        'debug',
+        {
+            DEFAULT  => 0,
+            ARGCOUNT => ARGCOUNT_NONE
+        }
+    );
+
+    # Read the configuration file if there is one
+    if (-e $conf_file) {
+        $CONF->file($conf_file);
+    }
+
+    # Process command line options
+    if ($opt_ad_server) {
+        $CONF->adserver($opt_ad_server);
+    }
+    if ($opt_base_dn) {
+        $CONF->base_dn($opt_base_dn);
+    }
+    if ($opt_computer_rdn) {
+        $CONF->computer_rdn($opt_computer_rdn);
+    }
+    if ($opt_user_rdn) {
+        $CONF->user_rdn($opt_user_rdn);
+    }
+    if ($opt_debug) {
+        $CONF->debug(1);
+    }
+
+    return;
+}
+
+# Show an example configuration file
+sub example_config {
+
+    msg("# Example configuration file to ad-keytab script");
+    msg("#");
+    msg("# The DNS name of the Active Directory server");
+    msg("ad_server = ad.microsoft.com");
+    msg("#");
+    msg("# The base distinguished name.  If not specified then msksutil");
+    msg("# will use the AD defaults for the DNs where objects are created.");
+    msg("base_dn = dc=microsoft,dc=internal");
+    msg("#");
+    msg("# The RDN used to create host/ keytabs.  The computer objects");
+    msg("# DN will be of the form cn=host/hostname,rdn,basedn.  While");
+    msg("# msktutil will use the AD default this script requires that");
+    msg("# that the RDN be specified explicitly.");
+    msg("computer_rdn = OU=Computers");
+    msg("#");
+    msg("# The Kerberos realm.  The AD default is usually fine.");
+    msg("#realm = MICROSOFT.INTERNAL");
+    msg("#");
+    msg("# The RDN used to create service/ keytabs.  The computer objects");
+    msg("# DN will be of the form cn=srv-service$,rdn,basedn.  While");
+    msg("# msktutil will use the AD default this script requires that");
+    msg("# that the RDN be specified explicitly.");
+    msg("user_rdn = OU=Users");
+    msg("#");
+    msg("# Debug flag");
+    msg("# debug = 1");
+
+    return;
+}
+
+# Decode Active Directory's userAccountControl attribute
+# Flags are powers of two starting at zero.
+sub list_userAccountControl {
+    my ($uac) = @_;
+    my @flags = (
+        'SCRIPT',
+        'ACCOUNTDISABLE',
+        'HOMEDIR_REQUIRED',
+        'LOCKOUT',
+        'PASSWD_NOTREQD',
+        'PASSWD_CANT_CHANGE',
+        'ENCRYPTED_TEXT_PWD_ALLOWED',
+        'TEMP_DUPLICATE_ACCOUNT',
+        'NORMAL_ACCOUNT',
+        'INTERDOMAIN_TRUST_ACCOUNT',
+        'WORKSTATION_TRUST_ACCOUNT',
+        'SERVER_TRUST_ACCOUNT',
+        'DONT_EXPIRE_PASSWORD',
+        'MNS_LOGON_ACCOUNT',
+        'SMARTCARD_REQUIRED',
+        'TRUSTED_FOR_DELEGATION',
+        'NOT_DELEGATED',
+        'USE_DES_KEY_ONLY',
+        'DONT_REQ_PREAUTH',
+        'PASSWORD_EXPIRED',
+        'TRUSTED_TO_AUTH_FOR_DELEGATION',
+        'PARTIAL_SECRETS_ACCOUNT'
+    );
+
+    my $flag_list;
+    my $comma = '';
+    for (my $i=0; $i<scalar(@flags); $i++) {
+        if ($uac & (2**$i)) {
+            $flag_list .= $comma . $flags[$i];
+            $comma = ', ';
+        }
+    }
+    return $flag_list;
+}
+
+# GSS-API bind to the active directory server
+sub ldap_connect {
+    my $ldap;
+    if ($CONF->debug) {
+        dbg('binding to ' . $CONF->ad_server);
+    }
+    if (!$CONF->ad_server) {
+        croak("Missing ldap host name, specify ad_server=\n");
+    }
+    eval {
+        my $sasl = Authen::SASL->new(mechanism => 'GSSAPI');
+        $ldap = Net::LDAP->new($CONF->ad_server, onerror => 'die');
+        my $mesg = eval { $ldap->bind(undef, sasl => $sasl) };
+    };
+    if ($@) {
+        my $error = $@;
+        die "ldap bind to AD failed: $error\n";
+    }
+    return $ldap;
+}
+
+# Take a principal and split into parts.  The parts are keytab type,
+# keytab identifier, the base dn, an LDAP filter, and if the keytab
+# type is host the host name.
+sub kerberos_attrs {
+    my ($principal) = @_;
+
+    my %attr = ();
+    my $dn;
+    my $host;
+    my $k_type;
+    my $k_id;
+    if ($principal =~ m,^(host|service)/(\S+),xms) {
+        $attr{type} = $1;
+        $attr{id}   = $2;
+        if ($attr{type} eq 'host') {
+            $attr{base}   = $CONF->computer_rdn . ',' . $CONF->base_dn;
+            $attr{dn}     = "cn=$attr{host},$attr{base}";
+            $attr{host}   = $attr{id};
+            $attr{host}   =~ s/[.].*//;
+            $attr{filter} = "(samAccountName=$attr{host}\$)";
+        } elsif ($attr{'type'} eq 'service') {
+            $attr{base}   = $CONF->user_rdn  . ',' . $CONF->base_dn;
+            $attr{dn}     = "cn=srv-$attr{id},$attr{base}";
+            $attr{filter} = "(servicePrincipalName=$attr{type}/$attr{id})";
+        }
+    }
+    if ($CONF->debug) {
+        for my $a (sort keys %attr) {
+            dbg("$a = $attr{$a}");
+        }
+    }
+    return %attr;
+}
+
+# Perform an LDAP search against AD and return information about
+# service and host accounts.
+sub ad_show {
+    my ($principal, $kattr_ref) = @_;
+
+    my $ldap = ldap_connect();
+    my %kattr = %{$kattr_ref};
+    my $base   = $kattr{base};
+    my $filter = $kattr{filter};
+    my @attrs = ();
+    if (!$opt_dump) {
+        @attrs = (
+            'distinguishedName',             'objectclass',
+            'dnsHostname',                   'msds-KeyVersionNumber',
+            'msds-SupportedEncryptionTypes', 'name',
+            'servicePrincipalName',          'samAccountName',
+            'userAccountControl',            'userPrincipalName',
+            'whenChanged',                   'whenCreated',
+            );
+    }
+
+    if ($CONF->debug) {
+        dbg("base:$base filter:$filter scope:subtree\n");
+    }
+
+    my $result;
+    eval {
+        $result = $ldap->search(
+            base   => $base,
+            scope  => 'subtree',
+            filter => $filter,
+            attrs  => \@attrs
+            );
+    };
+    if ($@) {
+        my $error = $@;
+        die "LDAP search error: $error\n";
+    }
+    if ($result->code) {
+        msg("INFO base:$base filter:$filter scope:subtree\n");
+        die $result->error;
+    }
+    if ($CONF->debug) {
+        dbg('returned: ' . $result->count);
+    }
+    if ($result->count > 0) {
+        for my $entry ($result->entries) {
+            for my $attr ( sort $entry->attributes ) {
+                my $out = '';
+                if ($attr =~ /userAccountControl/xmsi) {
+                    my $val = $entry->get_value($attr);
+                    $out = "$attr: $val";
+                    $out .= ' (' . list_userAccountControl($val) . ')';
+                    msg($out);
+                } else {
+                    my $val_ref = $entry->get_value($attr, asref => 1);
+                    my @vals = @{$val_ref};
+                    for my $val (@vals) {
+                        msg("$attr: $val");
+                    }
+                }
+            }
+        }
+    } else {
+        msg("$kattr{type}/$kattr{id} not found");
+    }
+    msg(' ');
+    return;
+}
+
+# Check to see if a keytab exists
+sub ad_exists {
+    my ($principal, $kattr_ref) = @_;
+
+    my $ldap = ldap_connect();
+    my %kattr = %{$kattr_ref};
+    my $base   = $kattr{base};
+    my $filter = $kattr{filter};
+    my @attrs = ('objectClass', 'msds-KeyVersionNumber');
+    if ($CONF->debug) {
+        dbg("base:$base filter:$filter scope:subtree\n");
+    }
+
+    my $result;
+    eval {
+        $result = $ldap->search(
+            base   => $base,
+            scope  => 'subtree',
+            filter => $filter,
+            attrs  => \@attrs
+            );
+    };
+    if ($@) {
+        my $error = $@;
+        die "LDAP search error: $error\n";
+    }
+    if ($result->code) {
+        msg("INFO base:$base filter:$filter scope:subtree\n");
+        die $result->error;
+    }
+    if ($CONF->debug) {
+        dbg('returned: ' . $result->count);
+    }
+    if ($result->count > 1) {
+        msg('ERROR: too many AD entries for this keytab');
+        for my $entry ($result->entries) {
+            msg('INFO: dn found ' . $entry->dn . "\n");
+        }
+        die("INFO: use show to examine the problem\n");
+    }
+    if ($result->count) {
+        for my $entry ($result->entries) {
+            return $entry->get_value('msds-KeyVersionNumber');
+        }
+    } else {
+        return 0;
+    }
+    return;
+}
+
+# Run a shell command.  In this case the command will always be msktutil.
+sub run_cmd {
+    my @cmd = @_;
+
+    if ($CONF->debug) {
+        dbg('running command:' . join(q{ }, @cmd));
+    }
+
+    my $in;
+    my $out;
+    my $err;
+    my $err_flag;
+    eval {
+        run(\@cmd, \$in, \$out, \$err, timeout(60));
+        if ($?) {
+            my $this_err = $?;
+            $err_flag = 1;
+            if ($this_err) {
+                msg('ERROR:' . $?);
+            }
+            if ($err) {
+                msg('ERROR (err):' . $err);
+            }
+        }
+    };
+    if ($@) {
+        msg('ERROR (status):' . $@);
+        $err_flag = 1;
+    }
+    if ($err_flag) {
+        msg('ERROR: Problem executing:' . join(q{ }, @cmd));
+        die "FATAL: Execution failed\n";
+    }
+
+    msg($out);
+    return;
+}
+
+# Either create or update a keytab for the principal.  Return the name
+# of the keytab file created.
+sub ad_create_update {
+    my ($principal, $file, $action) = @_;
+    my @cmd = ('/usr/sbin/msktutil');
+    push @cmd, '--' . $action;
+    push @cmd, '--server',   $CONF->ad_server;
+    push @cmd, '--enctypes', '0x4';
+    push @cmd, '--enctypes', '0x8';
+    push @cmd, '--enctypes', '0x10';
+    push @cmd, '--keytab',   $file;
+    if ($CONF->realm) {
+        push @cmd, '--realm', $CONF->realm;
+    }
+    if ($principal =~ m,^host/(\S+),xms) {
+        my $fqdn = $1;
+        my $host = $fqdn;
+        $host =~ s/[.].*//xms;
+        push @cmd, '--base', $CONF->computer_rdn;
+        push @cmd, '--dont-expire-password';
+        push @cmd, '--computer-name', $host;
+        push @cmd, '--upn',           "host/$fqdn";
+        push @cmd, '--hostname',      $fqdn;
+    } elsif ($principal =~ m,^service/(\S+),xms) {
+        my $service_id = $1;
+        push @cmd, '--base', $CONF->user_rdn;
+        push @cmd, '--use-service-account';
+        push @cmd, '--service',      "service/$service_id";
+        push @cmd, '--account-name', "srv-${service_id}";
+        push @cmd, '--no-pac';
+    }
+    run_cmd(@cmd);
+    return;
+}
+
+# Delete a principal from Kerberos.  For AD this means just delete the
+# object using LDAP.
+sub ad_delete {
+    my ($principal, $kattr_ref) = @_;
+
+    my %kattr = %{$kattr_ref};
+    if (!ad_exists($principal, $kattr_ref)) {
+        msg("WARN: the keytab for $principal does not appear to exist.");
+        msg("INFO: attempting the delete anyway.\n");
+    }
+
+    my $ldap = ldap_connect();
+
+    my $ldap = ldap_connect();
+    my $msgid = $ldap->delete($kattr{dn});
+    if ($msgid->code) {
+        my $m;
+        $m .= "ERROR: Problem deleting $kattr{dn}\n";
+        $m .= $msgid->error;
+        die $m;
+    }
+    return 1;
+}
+
+##############################################################################
+# Main Routine
+##############################################################################
+
+# -- get options
+GetOptions(
+    'ad_server=s'    => \$opt_ad_server,
+    'base_dn=s'      => \$opt_base_dn,
+    'computer_rdn=s' => \$opt_computer_rdn,
+    'config=s'       => \$opt_ad_server,
+    'debug'          => \$opt_debug,
+    'dump'           => \$opt_dump,
+    'example'        => \$opt_example,
+    'help'           => \$opt_help,
+    'manual'         => \$opt_manual,
+    'realm'          => \$opt_realm,
+    'user_rdn=s'     => \$opt_user_rdn
+);
+
+# -- help the poor souls out
+if ($opt_example) {
+    example_config();
+    exit 1;
+}
+if ($opt_manual) {
+    pod2usage(-verbose => 2);
+}
+if ($opt_help || !$ARGV[0]) {
+    pod2usage(-verbose => 0);
+}
+
+# Make sure that we have kerberos credentials and that KRB5CCNAME
+# points to them.
+if (!$ENV{'KRB5CCNAME'}) {
+    msg('ERROR: Kerberos credentials are required ... try kinit');
+    pod2usage(-verbose => 0);
+}
+
+# Read the configuration file if one exists
+my $conf_file;
+if ($ENV{'ADKEYTAB'}) {
+    $conf_file = $ENV{'ADKEYTAB'};
+} elsif (-e '.ad-keytab.conf') {
+    $conf_file = '.ad-keytab.conf';
+} else {
+    $conf_file = '/etc/ad-keytab.conf';
+}
+read_config($conf_file);
+
+# -- Get command line arguments
+my $action = shift;
+my $id     = shift;
+my $keytab;
+if ($ARGV[0]) {
+    $keytab = shift;
+} else {
+    $keytab = '/etc/krb5.keytab';
+}
+
+my %kattr = kerberos_attrs($id);
+# Validate that the keytab id makes sense for the keytab type
+if ($kattr{type} eq 'service') {
+    if ($kattr{id} =~ /[.]/xms) {
+        msg('ERROR: service principal names may not contain periods');
+        pod2usage(-verbose => 0);
+    }
+    if (length($kattr{id}) > 22) {
+        msg('ERROR: service principal name too long');
+        pod2usage(-verbose => 0);
+    }
+} elsif ($kattr{type} eq 'host') {
+    if ($kattr{id} !~ /[.]/xms) {
+        msg('ERROR: FQDN is required');
+        pod2usage(-verbose => 0);
+    }
+} else {
+    msg("ERROR: unknown keytab type $kattr{type}");
+    pod2usage(-verbose => 0);
+}
+
+if ($action =~ /^(create|update)/xms) {
+    ad_create_update($id, $keytab, $1);
+} elsif ($action =~ /^del/xms) {
+    ad_delete($id, \%kattr);
+} elsif ($action =~ /^sh/xms) {
+    ad_show($id, \%kattr);
+} else {
+    msg("ERROR: unknown action $action");
+    pod2usage(-verbose => 0);
+}
+
+exit;
+
+__END__
+
+=head1 NAME
+
+ad-keytab
+
+=head1 SYNOPSIS
+
+ad-keytab create|update|delete|show keytab-id [keytab-file]
+[--ad_server=hostname] [--computer_rdn=dn] [--user_rdn] [--example]
+[--dump] [--help] [--manual] [--debug]
+
+=head1 DESCRIPTION
+
+This script is a wrapper around msktutil to simplify the creation of
+host and service keytabs.  The script is useful for setting up AD a
+backend keytab store for wallet.  The script also enforces naming
+policies to conform with using Active Directory as a Kerberos KDC.
+
+=head1 ACTIONS
+
+=over 4
+
+=item create
+
+Add a keytab to AD and update the keytab file.  Fails if the keytab
+already exists.
+
+=item update
+
+Update an existing keytab in AD and update the keytab file.  Fails if
+the keytab does not exist.
+
+=item delete
+
+Delete a keytab from AD and remove it from the keytab file.
+
+=item show
+
+Show AD's view of the account corresponding to the keytab.  This action
+does not use msktutil and queries AD directly using LDAP.
+
+=back
+
+=head1 OPTIONS AND ARGUMENTS
+
+=over 4
+
+=item keytab-id
+
+This is either host principal name of the form host/<fqdn> or a
+service principal name of the form service/<id>.  Service keytab
+identifiers cannot be longer than 18 characters because of an
+ActiveDirectory restriction.
+
+=item keytab-filename
+
+The name of the keytab file.  Defaults to /etc/krb5.keytab.
+
+=item --conf=filename
+
+The configuration file to read.  The script searches for a configuration
+file in the following order.
+
+      * The command line switch --conf
+      * The environment variable ADKEYTAB
+      * The file .ad-keytab.conf
+      * The file /etc/ad-keytab.conf
+
+=item --ad_server=hostname
+
+The name of the Active Directory host to connect to.  It is important
+what the script contact only _one_ server due to the fact that
+propagation within an Active Directory domain can be quite slow.
+
+=item --base_dn=ou=org,dc=domain,dc=tld
+
+The base distinguished name holding both computer and user accounts.
+
+=item --computer_rdn=dn
+
+The relative distinguished name to use as the base DN for both the
+creation of host keytabs and searches of Active Directory.  The
+distinguished name formed will be computer_rdn,base_dn.
+
+=item --user_rdn=dn
+
+The relative distinguished name to use as the base DN for ldap
+searches of Active Directory for service keytabs.  The distinguished
+name formed will be user_rdn_rdn,base_dn.
+
+=item --dump
+
+When displaying keytab attributes show all of the attributes.
+
+=item --example
+
+Print an example configuration file to STDOUT.
+
+=item --help
+
+Displays help text.
+
+=item --manual
+
+Displays more complete help text.
+
+=item --debug
+
+Turns on debugging displays.
+
+=back
+
+=head1 AUTHOR
+
+Bill MacAllister <bill@ca-zephyr.org>
+
+=cut

--- a/perl/lib/Wallet/Config.pm
+++ b/perl/lib/Wallet/Config.pm
@@ -432,17 +432,17 @@ AD_CACHE must be set to use Active Directory support.
 
 our $AD_CACHE;
 
-=item AD_COMPUTER_DN
+=item AD_COMPUTER_RDN
 
 The LDAP base DN for computer objects inside Active Directory.  All keytabs of
 the form host/<hostname> will be mapped to objects with a C<samAccountName> of
 the <hostname> portion under this DN.
 
-AD_COMPUTER_DN must be set if using Active Directory as the keytab backend.
+AD_COMPUTER_RDN must be set if using Active Directory as the keytab backend.
 
 =cut
 
-our $AD_COMPUTER_DN;
+our $AD_COMPUTER_RDN;
 
 =item AD_DEBUG
 
@@ -464,17 +464,17 @@ default PATH.
 
 our $AD_MSKTUTIL = 'msktutil';
 
-=item AD_USER_DN
+=item AD_USER_RDN
 
 The LDAP base DN for user objects inside Active Directory.  All keytabs of the
 form service/<user> will be mapped to objects with a C<servicePrincipalName>
 matching the wallet object name under this DN.
 
-AD_USER_DN must be set if using Active Directory as the keytab backend.
+AD_USER_RDN must be set if using Active Directory as the keytab backend.
 
 =cut
 
-our $AD_USER_DN;
+our $AD_USER_RDN;
 
 =back
 
@@ -482,14 +482,20 @@ our $AD_USER_DN;
 
 Heimdal provides the choice, over the network protocol, of either
 downloading the existing keys for a principal or generating new random
-keys.  MIT Kerberos does not; downloading a keytab over the kadmin
-protocol always rekeys the principal.
+keys.  Neither MIT Kerberos or ActiveDirectory support retrieving an
+existing keytab; downloading a keytab over the kadmin protocol or
+using msktutil always rekeys the principal.
 
 For MIT Kerberos, the keytab object backend therefore optionally supports
 retrieving existing keys, and hence keytabs, for Kerberos principals by
 contacting the KDC via remctl and talking to B<keytab-backend>.  This is
 enabled by setting the C<unchanging> flag on keytab objects.  To configure
 that support, set the following variables.
+
+For ActiveDirectory Kerberos, the keytab object backend supports
+storing the keytabs on the wallet server.  This functionality is
+enabled by setting the configuration variable AD_KEYTAB_BUCKET.  (This
+had not been implemented yet.)
 
 This is not required for Heimdal; for Heimdal, setting the C<unchanging>
 flag is all that's needed.
@@ -541,6 +547,68 @@ will be used.
 =cut
 
 our $KEYTAB_REMCTL_PORT;
+
+=item AD_CACHE
+
+The ticket cache that hold credentials used to access the
+ActiveDirectory KDC.  This must be created and maintained externally.
+
+=cut
+
+our $AD_CACHE;
+
+=item AD_BASE_DN
+
+The base distinguished name of the ActiveDirectory instance.
+
+=cut
+
+our $AD_BASE_DN;
+
+=item AD_COMPUTER_RDN
+
+The relative distinguished name where host/ keytabs are stored in
+ActiveDirectory.
+
+=cut
+
+our $AD_COMPUTER_RDN;
+
+=item AD_USER_RDN
+
+The relative distinguished name where service/ keytabs are stored in
+ActiveDirectory.
+
+=cut
+
+our $AD_USER_RDN;
+
+=item AD_MSKTUTIL
+
+The path to mskutil.  msktutil is used to create or update keytabs
+stored in ActiveDirectory.
+
+=cut
+
+our $AD_MSKTUTIL = '/usr/sbin/msktutil';
+
+=item AD_DEBUG
+
+Turn on debugging displays for the ActiveDirectory KDC.
+
+=cut
+
+our $AD_DEBUG;
+
+=item AD_KEYTAB_BUCKET
+
+The path to store a copy of keytabs created.  This is required for the
+support of unchanging keytabs with an ActiveDirectory KDC.  (This has
+not been implemented yet.)
+
+=cut
+
+our $AD_KEYTAB_BUCKET = '/var/lib/wallet/keytabs';
 
 =back
 


### PR DESCRIPTION
This update includes the following changes.
- Resolves several problems that prevented creating of most keytabs using the AD backend.  
- Correctly sets the userPrincipalName in AD so that the original principal names for service keytabs can be used in addition to the AD specific samAccountName.  samAccountNames are restricted to 20 characters and must be unique.  For principal names that exceed this length a samAccountName is unique samAccountName is formed by truncating the original principal name and appending an integer.  This allows arbitrarily long principal names.
- The contributed script ad-keytab is installed by default.  The script can be used to boot strap the AD backend and to examine the raw AD keytab entries.
