### PR TITLE
correcting msktutil usage to support more enctypes

### DIFF
--- a/perl/lib/Wallet/Kadmin/AD.pm
+++ b/perl/lib/Wallet/Kadmin/AD.pm
@@ -184,9 +184,7 @@ sub ad_create_update {
     }
     my @cmd = ('--' . $action);
     push @cmd, '--server',   $Wallet::Config::AD_SERVER;
-    push @cmd, '--enctypes', '0x4';
-    push @cmd, '--enctypes', '0x8';
-    push @cmd, '--enctypes', '0x10';
+    push @cmd, '--enctypes', '0x1C';
     push @cmd, '--keytab',   $keytab;
     push @cmd, '--realm',    $Wallet::Config::KEYTAB_REALM;
 


### PR DESCRIPTION
with multiple enctypes specified, only the last one will actually take effect. If you wish to provide support for more then one, you need to add the values (0x04 + 0x08 + 0x10 = 0x1C). 
replacing the 3 lines with one line to enable all three. Note that the keytabs generated will have 3 lines for each principal (one for each enctypes).

See msktutil man page for further details on enctypes.