### PR TITLE
Add acl comment and some build chagnes

### DIFF
--- a/perl/lib/Wallet/Object/Base.pm
+++ b/perl/lib/Wallet/Object/Base.pm
@@ -24,6 +24,8 @@ use Wallet::ACL;
 
 our $VERSION = '1.04';
 
+my $TZ = DateTime::TimeZone->new( name => 'local' );
+
 ##############################################################################
 # Constructors
 ##############################################################################
@@ -60,7 +62,7 @@ sub create {
     die "invalid object name\n" unless $name;
     my $guard = $schema->txn_scope_guard;
     eval {
-        my $date = DateTime->from_epoch (epoch => $time);
+        my $date = DateTime->from_epoch (epoch => $time, time_zone => $TZ);
         my %record = (ob_type         => $type,
                       ob_name         => $name,
                       ob_created_by   => $user,
@@ -134,7 +136,7 @@ sub log_action {
     # assume that AutoCommit is turned off.
     my $guard = $self->{schema}->txn_scope_guard;
     eval {
-        my $date = DateTime->from_epoch (epoch => $time);
+        my $date = DateTime->from_epoch (epoch => $time, time_zone => $TZ);
         my %record = (oh_type   => $self->{type},
                       oh_name   => $self->{name},
                       oh_action => $action,
@@ -188,7 +190,7 @@ sub log_set {
         die "invalid history field $field";
     }
 
-    my $date = DateTime->from_epoch (epoch => $time);
+    my $date = DateTime->from_epoch (epoch => $time, time_zone => $TZ);
     my %record = (oh_type       => $self->{type},
                   oh_name       => $self->{name},
                   oh_action     => 'set',
@@ -353,7 +355,7 @@ sub expires {
             $self->error ("malformed expiration time $expires");
             return;
         }
-        my $date = DateTime->from_epoch (epoch => $seconds);
+        my $date = DateTime->from_epoch (epoch => $seconds, time_zone => $TZ);
         return $self->_set_internal ('expires', $date, $user, $host, $time);
     } elsif (defined $expires) {
         return $self->_set_internal ('expires', undef, $user, $host, $time);
@@ -743,7 +745,7 @@ sub destroy {
         $self->{schema}->resultset('Object')->search (\%search)->delete;
 
         # And create a new history object for the destroy action.
-        my $date = DateTime->from_epoch (epoch => $time);
+        my $date = DateTime->from_epoch (epoch => $time, time_zone => $TZ);
         my %record = (oh_type => $type,
                       oh_name => $name,
                       oh_action => 'destroy',

--- a/perl/lib/Wallet/Report.pm
+++ b/perl/lib/Wallet/Report.pm
@@ -504,7 +504,8 @@ sub acls_unused {
 }
 
 # Obtain a textual representation of the membership of an ACL, returning undef
-# on error and setting the internal error.
+# on error and setting the internal error. Make sure the membership is sorted
+# so that comparisons are possible.
 sub acl_membership {
     my ($self, $id) = @_;
     my $acl = eval { Wallet::ACL->new ($id, $self->{schema}) };
@@ -512,7 +513,9 @@ sub acl_membership {
         $self->error ($@);
         return;
     }
-    my @members = map { "$_->[0] $_->[1]" } $acl->list;
+    my @entries = $acl->list;
+    my @entries_sorted = sort { $$a[0] cmp $$b[0] or $$a[1] cmp $$b[1] } @entries;
+    my @members = map { "$_->[0] $_->[1]" } @entries_sorted;
     if (!@members && $acl->error) {
         $self->error ($acl->error);
         return;

--- a/perl/lib/Wallet/Schema.pm
+++ b/perl/lib/Wallet/Schema.pm
@@ -20,7 +20,7 @@ use base 'DBIx::Class::Schema';
 # Unlike all of the other wallet modules, this module's version is tied to the
 # version of the schema in the database.  It should only be changed on schema
 # changes, at least until better handling of upgrades is available.
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 
 __PACKAGE__->load_namespaces;
 __PACKAGE__->load_components (qw/Schema::Versioned/);
@@ -50,6 +50,7 @@ sub connect {
     my $user = $Wallet::Config::DB_USER;
     my $pass = $Wallet::Config::DB_PASSWORD;
     my %attrs = (PrintError => 0, RaiseError => 1);
+
     my $schema = eval { $class->SUPER::connect ($dsn, $user, $pass, \%attrs) };
     if ($@) {
         die "cannot connect to database: $@\n";

--- a/perl/lib/Wallet/Schema/Result/Acl.pm
+++ b/perl/lib/Wallet/Schema/Result/Acl.pm
@@ -42,6 +42,12 @@ __PACKAGE__->table("acls");
   is_nullable: 0
   size: 255
 
+=head2 ac_comment
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 255
+
 =cut
 
 __PACKAGE__->add_columns(
@@ -49,6 +55,8 @@ __PACKAGE__->add_columns(
   { data_type => "integer", is_auto_increment => 1, is_nullable => 0 },
   "ac_name",
   { data_type => "varchar", is_nullable => 0, size => 255 },
+  "ac_comment",
+  { data_type => "varchar", is_nullable => 1, size => 255 },
 );
 __PACKAGE__->set_primary_key("ac_id");
 __PACKAGE__->add_unique_constraint("ac_name", ["ac_name"]);

--- a/perl/lib/Wallet/Server.pm
+++ b/perl/lib/Wallet/Server.pm
@@ -633,6 +633,32 @@ sub acl_check {
     return 1;
 }
 
+# Retrieves or sets the comment of an ACL. We don't record comment changes
+# to the ACL history table.
+sub acl_comment {
+    my ($self, $id, $comment) = @_;
+    unless ($self->{admin}->check ($self->{user})) {
+        $self->acl_error ($id, 'comment');
+        return;
+    }
+    my $acl = eval { Wallet::ACL->new ($id, $self->{schema}) };
+    if ($@) {
+        $self->error ($@);
+        return;
+    }
+
+    my $result;
+    if (defined $comment) {
+        $result = $acl->set_comment ($comment);
+    } else {
+        return $acl->get_comment();
+    }
+    if (not defined ($result) and $acl->error) {
+        $self->error ($acl->error);
+    }
+    return $result;
+}
+
 # Create a new empty ACL in the database.  Returns true on success and undef
 # on failure, setting the internal error.
 sub acl_create {

--- a/perl/sql/Wallet-Schema-0.10-0.11-MySQL.sql
+++ b/perl/sql/Wallet-Schema-0.10-0.11-MySQL.sql
@@ -1,0 +1,9 @@
+-- Convert schema 'sql/Wallet-Schema-0.10-MySQL.sql' to 'Wallet::Schema v0.11':;
+
+BEGIN;
+
+ALTER TABLE acls ADD COLUMN ac_comment varchar(255);
+
+COMMIT;
+
+

--- a/perl/sql/Wallet-Schema-0.10-0.11-PostgreSQL.sql
+++ b/perl/sql/Wallet-Schema-0.10-0.11-PostgreSQL.sql
@@ -1,0 +1,8 @@
+-- Convert schema 'sql/Wallet-Schema-0.10-PostgreSQL.sql' to 'sql/Wallet-Schema-0.11-PostgreSQL.sql':;
+
+BEGIN;
+
+ALTER TABLE acls ADD COLUMN ac_comment character varying(255) NULL;
+
+COMMIT;
+

--- a/perl/sql/Wallet-Schema-0.10-0.11-SQLite.sql
+++ b/perl/sql/Wallet-Schema-0.10-0.11-SQLite.sql
@@ -1,0 +1,7 @@
+-- Convert schema 'sql/Wallet-Schema-0.10-SQLite.sql' to 'sql/Wallet-Schema-0.11-SQLite.sql':;
+
+BEGIN;
+
+ALTER TABLE acls ADD ac_comment varchar(255) default null;
+
+COMMIT;

--- a/perl/sql/Wallet-Schema-0.11-MySQL.sql
+++ b/perl/sql/Wallet-Schema-0.11-MySQL.sql
@@ -1,0 +1,216 @@
+-- 
+-- Created by SQL::Translator::Producer::MySQL
+-- Created on Thu Oct  9 20:54:55 2014
+-- 
+-- Copyright 2014
+--     The Board of Trustees of the Leland Stanford Junior University
+--
+-- SPDX-License-Identifier: MIT
+--
+
+SET foreign_key_checks=0;
+
+DROP TABLE IF EXISTS `acl_history`;
+
+--
+-- Table: `acl_history`
+--
+CREATE TABLE `acl_history` (
+  `ah_id` integer NOT NULL auto_increment,
+  `ah_acl` integer NOT NULL,
+  `ah_name` varchar(255) NULL,
+  `ah_action` varchar(16) NOT NULL,
+  `ah_scheme` varchar(32) NULL,
+  `ah_identifier` varchar(255) NULL,
+  `ah_by` varchar(255) NOT NULL,
+  `ah_from` varchar(255) NOT NULL,
+  `ah_on` datetime NOT NULL,
+  INDEX `acl_history_idx_ah_acl` (`ah_acl`),
+  INDEX `acl_history_idx_ah_name` (`ah_name`),
+  PRIMARY KEY (`ah_id`)
+) CHARACTER SET latin1 COLLATE latin1_swedish_ci;
+
+DROP TABLE IF EXISTS `acl_schemes`;
+
+--
+-- Table: `acl_schemes`
+--
+CREATE TABLE `acl_schemes` (
+  `as_name` varchar(32) NOT NULL,
+  `as_class` varchar(64) NULL,
+  PRIMARY KEY (`as_name`)
+) CHARACTER SET latin1 COLLATE latin1_swedish_ci ENGINE=InnoDB;
+
+DROP TABLE IF EXISTS `acls`;
+
+--
+-- Table: `acls`
+--
+CREATE TABLE `acls` (
+  `ac_id` integer NOT NULL auto_increment,
+  `ac_name` varchar(255) NOT NULL,
+  `ac_comment` varchar(255) NULL,
+  PRIMARY KEY (`ac_id`),
+  UNIQUE `ac_name` (`ac_name`)
+) CHARACTER SET latin1 COLLATE latin1_swedish_ci ENGINE=InnoDB;
+
+DROP TABLE IF EXISTS `enctypes`;
+
+--
+-- Table: `enctypes`
+--
+CREATE TABLE `enctypes` (
+  `en_name` varchar(255) NOT NULL,
+  PRIMARY KEY (`en_name`)
+) CHARACTER SET latin1 COLLATE latin1_swedish_ci;
+
+DROP TABLE IF EXISTS `flags`;
+
+--
+-- Table: `flags`
+--
+CREATE TABLE `flags` (
+  `fl_type` varchar(16) NOT NULL,
+  `fl_name` varchar(255) NOT NULL,
+  `fl_flag` enum('locked', 'unchanging') NOT NULL,
+  PRIMARY KEY (`fl_type`, `fl_name`, `fl_flag`)
+) CHARACTER SET latin1 COLLATE latin1_swedish_ci;
+
+DROP TABLE IF EXISTS `keytab_enctypes`;
+
+--
+-- Table: `keytab_enctypes`
+--
+CREATE TABLE `keytab_enctypes` (
+  `ke_name` varchar(255) NOT NULL,
+  `ke_enctype` varchar(255) NOT NULL,
+  PRIMARY KEY (`ke_name`, `ke_enctype`)
+) CHARACTER SET latin1 COLLATE latin1_swedish_ci;
+
+DROP TABLE IF EXISTS `keytab_sync`;
+
+--
+-- Table: `keytab_sync`
+--
+CREATE TABLE `keytab_sync` (
+  `ks_name` varchar(255) NOT NULL,
+  `ks_target` varchar(255) NOT NULL,
+  PRIMARY KEY (`ks_name`, `ks_target`)
+) CHARACTER SET latin1 COLLATE latin1_swedish_ci;
+
+DROP TABLE IF EXISTS `object_history`;
+
+--
+-- Table: `object_history`
+--
+CREATE TABLE `object_history` (
+  `oh_id` integer NOT NULL auto_increment,
+  `oh_type` varchar(16) NOT NULL,
+  `oh_name` varchar(255) NOT NULL,
+  `oh_action` varchar(16) NOT NULL,
+  `oh_field` varchar(16) NULL,
+  `oh_type_field` varchar(255) NULL,
+  `oh_old` varchar(255) NULL,
+  `oh_new` varchar(255) NULL,
+  `oh_by` varchar(255) NOT NULL,
+  `oh_from` varchar(255) NOT NULL,
+  `oh_on` datetime NOT NULL,
+  INDEX `object_history_idx_oh_type_oh_name` (`oh_type`, `oh_name`),
+  PRIMARY KEY (`oh_id`)
+) CHARACTER SET latin1 COLLATE latin1_swedish_ci;
+
+DROP TABLE IF EXISTS `sync_targets`;
+
+--
+-- Table: `sync_targets`
+--
+CREATE TABLE `sync_targets` (
+  `st_name` varchar(255) NOT NULL,
+  PRIMARY KEY (`st_name`)
+) CHARACTER SET latin1 COLLATE latin1_swedish_ci;
+
+DROP TABLE IF EXISTS `types`;
+
+--
+-- Table: `types`
+--
+CREATE TABLE `types` (
+  `ty_name` varchar(16) NOT NULL,
+  `ty_class` varchar(64) NULL,
+  PRIMARY KEY (`ty_name`)
+) CHARACTER SET latin1 COLLATE latin1_swedish_ci ENGINE=InnoDB;
+
+DROP TABLE IF EXISTS `acl_entries`;
+
+--
+-- Table: `acl_entries`
+--
+CREATE TABLE `acl_entries` (
+  `ae_id` integer NOT NULL,
+  `ae_scheme` varchar(32) NOT NULL,
+  `ae_identifier` varchar(255) NOT NULL,
+  INDEX `acl_entries_idx_ae_scheme` (`ae_scheme`),
+  INDEX `acl_entries_idx_ae_id` (`ae_id`),
+  PRIMARY KEY (`ae_id`, `ae_scheme`, `ae_identifier`),
+  CONSTRAINT `acl_entries_fk_ae_scheme` FOREIGN KEY (`ae_scheme`) REFERENCES `acl_schemes` (`as_name`),
+  CONSTRAINT `acl_entries_fk_ae_id` FOREIGN KEY (`ae_id`) REFERENCES `acls` (`ac_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) CHARACTER SET latin1 COLLATE latin1_swedish_ci ENGINE=InnoDB;
+
+DROP TABLE IF EXISTS `objects`;
+
+--
+-- Table: `objects`
+--
+CREATE TABLE `objects` (
+  `ob_type` varchar(16) NOT NULL,
+  `ob_name` varchar(255) NOT NULL,
+  `ob_owner` integer NULL,
+  `ob_acl_get` integer NULL,
+  `ob_acl_store` integer NULL,
+  `ob_acl_show` integer NULL,
+  `ob_acl_destroy` integer NULL,
+  `ob_acl_flags` integer NULL,
+  `ob_expires` datetime NULL,
+  `ob_created_by` varchar(255) NOT NULL,
+  `ob_created_from` varchar(255) NOT NULL,
+  `ob_created_on` datetime NOT NULL,
+  `ob_stored_by` varchar(255) NULL,
+  `ob_stored_from` varchar(255) NULL,
+  `ob_stored_on` datetime NULL,
+  `ob_downloaded_by` varchar(255) NULL,
+  `ob_downloaded_from` varchar(255) NULL,
+  `ob_downloaded_on` datetime NULL,
+  `ob_comment` varchar(255) NULL,
+  INDEX `objects_idx_ob_acl_destroy` (`ob_acl_destroy`),
+  INDEX `objects_idx_ob_acl_flags` (`ob_acl_flags`),
+  INDEX `objects_idx_ob_acl_get` (`ob_acl_get`),
+  INDEX `objects_idx_ob_owner` (`ob_owner`),
+  INDEX `objects_idx_ob_acl_show` (`ob_acl_show`),
+  INDEX `objects_idx_ob_acl_store` (`ob_acl_store`),
+  INDEX `objects_idx_ob_type` (`ob_type`),
+  PRIMARY KEY (`ob_name`, `ob_type`),
+  CONSTRAINT `objects_fk_ob_acl_destroy` FOREIGN KEY (`ob_acl_destroy`) REFERENCES `acls` (`ac_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `objects_fk_ob_acl_flags` FOREIGN KEY (`ob_acl_flags`) REFERENCES `acls` (`ac_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `objects_fk_ob_acl_get` FOREIGN KEY (`ob_acl_get`) REFERENCES `acls` (`ac_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `objects_fk_ob_owner` FOREIGN KEY (`ob_owner`) REFERENCES `acls` (`ac_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `objects_fk_ob_acl_show` FOREIGN KEY (`ob_acl_show`) REFERENCES `acls` (`ac_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `objects_fk_ob_acl_store` FOREIGN KEY (`ob_acl_store`) REFERENCES `acls` (`ac_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `objects_fk_ob_type` FOREIGN KEY (`ob_type`) REFERENCES `types` (`ty_name`)
+) CHARACTER SET latin1 COLLATE latin1_swedish_ci ENGINE=InnoDB;
+
+DROP TABLE IF EXISTS `duo`;
+
+--
+-- Table: `duo`
+--
+CREATE TABLE `duo` (
+  `du_name` varchar(255) NOT NULL,
+  `du_type` varchar(16) NOT NULL,
+  `du_key` varchar(255) NOT NULL,
+  INDEX `duo_idx_du_type_du_name` (`du_type`, `du_name`),
+  PRIMARY KEY (`du_name`, `du_type`),
+  CONSTRAINT `duo_fk_du_type_du_name` FOREIGN KEY (`du_type`, `du_name`) REFERENCES `objects` (`ob_type`, `ob_name`)
+) CHARACTER SET latin1 COLLATE latin1_swedish_ci ENGINE=InnoDB;
+
+SET foreign_key_checks=1;
+

--- a/perl/sql/Wallet-Schema-0.11-PostgreSQL.sql
+++ b/perl/sql/Wallet-Schema-0.11-PostgreSQL.sql
@@ -1,0 +1,223 @@
+-- 
+-- Created by SQL::Translator::Producer::PostgreSQL
+-- Created on Thu Oct  9 20:54:56 2014
+-- 
+-- Copyright 2014
+--     The Board of Trustees of the Leland Stanford Junior University
+--
+-- SPDX-License-Identifier: MIT
+--
+
+--
+-- Table: acl_history.
+--
+DROP TABLE IF EXISTS "acl_history" CASCADE;
+CREATE TABLE "acl_history" (
+  "ah_id" serial NOT NULL,
+  "ah_acl" integer NOT NULL,
+  "ah_name" character varying(255),
+  "ah_action" character varying(16) NOT NULL,
+  "ah_scheme" character varying(32),
+  "ah_identifier" character varying(255),
+  "ah_by" character varying(255) NOT NULL,
+  "ah_from" character varying(255) NOT NULL,
+  "ah_on" timestamp NOT NULL,
+  PRIMARY KEY ("ah_id")
+);
+CREATE INDEX "acl_history_idx_ah_acl" on "acl_history" ("ah_acl");
+CREATE INDEX "acl_history_idx_ah_name" on "acl_history" ("ah_name");
+
+--
+-- Table: acl_schemes.
+--
+DROP TABLE IF EXISTS "acl_schemes" CASCADE;
+CREATE TABLE "acl_schemes" (
+  "as_name" character varying(32) NOT NULL,
+  "as_class" character varying(64),
+  PRIMARY KEY ("as_name")
+);
+
+--
+-- Table: acls.
+--
+DROP TABLE IF EXISTS "acls" CASCADE;
+CREATE TABLE "acls" (
+  "ac_id" serial NOT NULL,
+  "ac_name" character varying(255) NOT NULL,
+  "ac_comment" character varying(255),
+  PRIMARY KEY ("ac_id"),
+  CONSTRAINT "ac_name" UNIQUE ("ac_name")
+);
+
+--
+-- Table: enctypes.
+--
+DROP TABLE IF EXISTS "enctypes" CASCADE;
+CREATE TABLE "enctypes" (
+  "en_name" character varying(255) NOT NULL,
+  PRIMARY KEY ("en_name")
+);
+
+--
+-- Table: flags.
+--
+DROP TABLE IF EXISTS "flags" CASCADE;
+CREATE TABLE "flags" (
+  "fl_type" character varying(16) NOT NULL,
+  "fl_name" character varying(255) NOT NULL,
+  "fl_flag" character varying NOT NULL,
+  PRIMARY KEY ("fl_type", "fl_name", "fl_flag")
+);
+
+--
+-- Table: keytab_enctypes.
+--
+DROP TABLE IF EXISTS "keytab_enctypes" CASCADE;
+CREATE TABLE "keytab_enctypes" (
+  "ke_name" character varying(255) NOT NULL,
+  "ke_enctype" character varying(255) NOT NULL,
+  PRIMARY KEY ("ke_name", "ke_enctype")
+);
+
+--
+-- Table: keytab_sync.
+--
+DROP TABLE IF EXISTS "keytab_sync" CASCADE;
+CREATE TABLE "keytab_sync" (
+  "ks_name" character varying(255) NOT NULL,
+  "ks_target" character varying(255) NOT NULL,
+  PRIMARY KEY ("ks_name", "ks_target")
+);
+
+--
+-- Table: object_history.
+--
+DROP TABLE IF EXISTS "object_history" CASCADE;
+CREATE TABLE "object_history" (
+  "oh_id" serial NOT NULL,
+  "oh_type" character varying(16) NOT NULL,
+  "oh_name" character varying(255) NOT NULL,
+  "oh_action" character varying(16) NOT NULL,
+  "oh_field" character varying(16),
+  "oh_type_field" character varying(255),
+  "oh_old" character varying(255),
+  "oh_new" character varying(255),
+  "oh_by" character varying(255) NOT NULL,
+  "oh_from" character varying(255) NOT NULL,
+  "oh_on" timestamp NOT NULL,
+  PRIMARY KEY ("oh_id")
+);
+CREATE INDEX "object_history_idx_oh_type_oh_name" on "object_history" ("oh_type", "oh_name");
+
+--
+-- Table: sync_targets.
+--
+DROP TABLE IF EXISTS "sync_targets" CASCADE;
+CREATE TABLE "sync_targets" (
+  "st_name" character varying(255) NOT NULL,
+  PRIMARY KEY ("st_name")
+);
+
+--
+-- Table: types.
+--
+DROP TABLE IF EXISTS "types" CASCADE;
+CREATE TABLE "types" (
+  "ty_name" character varying(16) NOT NULL,
+  "ty_class" character varying(64),
+  PRIMARY KEY ("ty_name")
+);
+
+--
+-- Table: acl_entries.
+--
+DROP TABLE IF EXISTS "acl_entries" CASCADE;
+CREATE TABLE "acl_entries" (
+  "ae_id" integer NOT NULL,
+  "ae_scheme" character varying(32) NOT NULL,
+  "ae_identifier" character varying(255) NOT NULL,
+  PRIMARY KEY ("ae_id", "ae_scheme", "ae_identifier")
+);
+CREATE INDEX "acl_entries_idx_ae_scheme" on "acl_entries" ("ae_scheme");
+CREATE INDEX "acl_entries_idx_ae_id" on "acl_entries" ("ae_id");
+
+--
+-- Table: objects.
+--
+DROP TABLE IF EXISTS "objects" CASCADE;
+CREATE TABLE "objects" (
+  "ob_type" character varying(16) NOT NULL,
+  "ob_name" character varying(255) NOT NULL,
+  "ob_owner" integer,
+  "ob_acl_get" integer,
+  "ob_acl_store" integer,
+  "ob_acl_show" integer,
+  "ob_acl_destroy" integer,
+  "ob_acl_flags" integer,
+  "ob_expires" timestamp,
+  "ob_created_by" character varying(255) NOT NULL,
+  "ob_created_from" character varying(255) NOT NULL,
+  "ob_created_on" timestamp NOT NULL,
+  "ob_stored_by" character varying(255),
+  "ob_stored_from" character varying(255),
+  "ob_stored_on" timestamp,
+  "ob_downloaded_by" character varying(255),
+  "ob_downloaded_from" character varying(255),
+  "ob_downloaded_on" timestamp,
+  "ob_comment" character varying(255),
+  PRIMARY KEY ("ob_name", "ob_type")
+);
+CREATE INDEX "objects_idx_ob_acl_destroy" on "objects" ("ob_acl_destroy");
+CREATE INDEX "objects_idx_ob_acl_flags" on "objects" ("ob_acl_flags");
+CREATE INDEX "objects_idx_ob_acl_get" on "objects" ("ob_acl_get");
+CREATE INDEX "objects_idx_ob_owner" on "objects" ("ob_owner");
+CREATE INDEX "objects_idx_ob_acl_show" on "objects" ("ob_acl_show");
+CREATE INDEX "objects_idx_ob_acl_store" on "objects" ("ob_acl_store");
+CREATE INDEX "objects_idx_ob_type" on "objects" ("ob_type");
+
+--
+-- Table: duo.
+--
+DROP TABLE IF EXISTS "duo" CASCADE;
+CREATE TABLE "duo" (
+  "du_name" character varying(255) NOT NULL,
+  "du_type" character varying(16) NOT NULL,
+  "du_key" character varying(255) NOT NULL,
+  PRIMARY KEY ("du_name", "du_type")
+);
+CREATE INDEX "duo_idx_du_type_du_name" on "duo" ("du_type", "du_name");
+
+--
+-- Foreign Key Definitions
+--
+
+ALTER TABLE "acl_entries" ADD CONSTRAINT "acl_entries_fk_ae_scheme" FOREIGN KEY ("ae_scheme")
+  REFERENCES "acl_schemes" ("as_name") DEFERRABLE;
+
+ALTER TABLE "acl_entries" ADD CONSTRAINT "acl_entries_fk_ae_id" FOREIGN KEY ("ae_id")
+  REFERENCES "acls" ("ac_id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+ALTER TABLE "objects" ADD CONSTRAINT "objects_fk_ob_acl_destroy" FOREIGN KEY ("ob_acl_destroy")
+  REFERENCES "acls" ("ac_id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+ALTER TABLE "objects" ADD CONSTRAINT "objects_fk_ob_acl_flags" FOREIGN KEY ("ob_acl_flags")
+  REFERENCES "acls" ("ac_id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+ALTER TABLE "objects" ADD CONSTRAINT "objects_fk_ob_acl_get" FOREIGN KEY ("ob_acl_get")
+  REFERENCES "acls" ("ac_id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+ALTER TABLE "objects" ADD CONSTRAINT "objects_fk_ob_owner" FOREIGN KEY ("ob_owner")
+  REFERENCES "acls" ("ac_id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+ALTER TABLE "objects" ADD CONSTRAINT "objects_fk_ob_acl_show" FOREIGN KEY ("ob_acl_show")
+  REFERENCES "acls" ("ac_id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+ALTER TABLE "objects" ADD CONSTRAINT "objects_fk_ob_acl_store" FOREIGN KEY ("ob_acl_store")
+  REFERENCES "acls" ("ac_id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE;
+
+ALTER TABLE "objects" ADD CONSTRAINT "objects_fk_ob_type" FOREIGN KEY ("ob_type")
+  REFERENCES "types" ("ty_name") DEFERRABLE;
+
+ALTER TABLE "duo" ADD CONSTRAINT "duo_fk_du_type_du_name" FOREIGN KEY ("du_type", "du_name")
+  REFERENCES "objects" ("ob_type", "ob_name") DEFERRABLE;
+

--- a/perl/sql/Wallet-Schema-0.11-SQLite.sql
+++ b/perl/sql/Wallet-Schema-0.11-SQLite.sql
@@ -1,0 +1,226 @@
+--
+-- Created by SQL::Translator::Producer::SQLite
+-- Created on Thu Oct  9 20:51:25 2014
+-- 
+-- Copyright 2014
+--     The Board of Trustees of the Leland Stanford Junior University
+--
+-- SPDX-License-Identifier: MIT
+--
+
+BEGIN TRANSACTION;
+
+--
+-- Table: acl_history
+--
+DROP TABLE IF EXISTS acl_history;
+
+CREATE TABLE acl_history (
+  ah_id INTEGER PRIMARY KEY NOT NULL,
+  ah_acl integer NOT NULL,
+  ah_name varchar(255),
+  ah_action varchar(16) NOT NULL,
+  ah_scheme varchar(32),
+  ah_identifier varchar(255),
+  ah_by varchar(255) NOT NULL,
+  ah_from varchar(255) NOT NULL,
+  ah_on datetime NOT NULL
+);
+
+CREATE INDEX acl_history_idx_ah_acl ON acl_history (ah_acl);
+
+CREATE INDEX acl_history_idx_ah_name ON acl_history (ah_name);
+
+--
+-- Table: acl_schemes
+--
+DROP TABLE IF EXISTS acl_schemes;
+
+CREATE TABLE acl_schemes (
+  as_name varchar(32) NOT NULL,
+  as_class varchar(64),
+  PRIMARY KEY (as_name)
+);
+
+--
+-- Table: acls
+--
+DROP TABLE IF EXISTS acls;
+
+CREATE TABLE acls (
+  ac_id INTEGER PRIMARY KEY NOT NULL,
+  ac_name varchar(255) NOT NULL,
+  ac_comment varchar(255)
+);
+
+CREATE UNIQUE INDEX ac_name ON acls (ac_name);
+
+--
+-- Table: enctypes
+--
+DROP TABLE IF EXISTS enctypes;
+
+CREATE TABLE enctypes (
+  en_name varchar(255) NOT NULL,
+  PRIMARY KEY (en_name)
+);
+
+--
+-- Table: flags
+--
+DROP TABLE IF EXISTS flags;
+
+CREATE TABLE flags (
+  fl_type varchar(16) NOT NULL,
+  fl_name varchar(255) NOT NULL,
+  fl_flag enum NOT NULL,
+  PRIMARY KEY (fl_type, fl_name, fl_flag)
+);
+
+--
+-- Table: keytab_enctypes
+--
+DROP TABLE IF EXISTS keytab_enctypes;
+
+CREATE TABLE keytab_enctypes (
+  ke_name varchar(255) NOT NULL,
+  ke_enctype varchar(255) NOT NULL,
+  PRIMARY KEY (ke_name, ke_enctype)
+);
+
+--
+-- Table: keytab_sync
+--
+DROP TABLE IF EXISTS keytab_sync;
+
+CREATE TABLE keytab_sync (
+  ks_name varchar(255) NOT NULL,
+  ks_target varchar(255) NOT NULL,
+  PRIMARY KEY (ks_name, ks_target)
+);
+
+--
+-- Table: object_history
+--
+DROP TABLE IF EXISTS object_history;
+
+CREATE TABLE object_history (
+  oh_id INTEGER PRIMARY KEY NOT NULL,
+  oh_type varchar(16) NOT NULL,
+  oh_name varchar(255) NOT NULL,
+  oh_action varchar(16) NOT NULL,
+  oh_field varchar(16),
+  oh_type_field varchar(255),
+  oh_old varchar(255),
+  oh_new varchar(255),
+  oh_by varchar(255) NOT NULL,
+  oh_from varchar(255) NOT NULL,
+  oh_on datetime NOT NULL
+);
+
+CREATE INDEX object_history_idx_oh_type_oh_name ON object_history (oh_type, oh_name);
+
+--
+-- Table: sync_targets
+--
+DROP TABLE IF EXISTS sync_targets;
+
+CREATE TABLE sync_targets (
+  st_name varchar(255) NOT NULL,
+  PRIMARY KEY (st_name)
+);
+
+--
+-- Table: types
+--
+DROP TABLE IF EXISTS types;
+
+CREATE TABLE types (
+  ty_name varchar(16) NOT NULL,
+  ty_class varchar(64),
+  PRIMARY KEY (ty_name)
+);
+
+--
+-- Table: acl_entries
+--
+DROP TABLE IF EXISTS acl_entries;
+
+CREATE TABLE acl_entries (
+  ae_id integer NOT NULL,
+  ae_scheme varchar(32) NOT NULL,
+  ae_identifier varchar(255) NOT NULL,
+  PRIMARY KEY (ae_id, ae_scheme, ae_identifier),
+  FOREIGN KEY (ae_scheme) REFERENCES acl_schemes(as_name),
+  FOREIGN KEY (ae_id) REFERENCES acls(ac_id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX acl_entries_idx_ae_scheme ON acl_entries (ae_scheme);
+
+CREATE INDEX acl_entries_idx_ae_id ON acl_entries (ae_id);
+
+--
+-- Table: objects
+--
+DROP TABLE IF EXISTS objects;
+
+CREATE TABLE objects (
+  ob_type varchar(16) NOT NULL,
+  ob_name varchar(255) NOT NULL,
+  ob_owner integer,
+  ob_acl_get integer,
+  ob_acl_store integer,
+  ob_acl_show integer,
+  ob_acl_destroy integer,
+  ob_acl_flags integer,
+  ob_expires datetime,
+  ob_created_by varchar(255) NOT NULL,
+  ob_created_from varchar(255) NOT NULL,
+  ob_created_on datetime NOT NULL,
+  ob_stored_by varchar(255),
+  ob_stored_from varchar(255),
+  ob_stored_on datetime,
+  ob_downloaded_by varchar(255),
+  ob_downloaded_from varchar(255),
+  ob_downloaded_on datetime,
+  ob_comment varchar(255),
+  PRIMARY KEY (ob_name, ob_type),
+  FOREIGN KEY (ob_acl_destroy) REFERENCES acls(ac_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (ob_acl_flags) REFERENCES acls(ac_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (ob_acl_get) REFERENCES acls(ac_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (ob_owner) REFERENCES acls(ac_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (ob_acl_show) REFERENCES acls(ac_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (ob_acl_store) REFERENCES acls(ac_id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (ob_type) REFERENCES types(ty_name)
+);
+
+CREATE INDEX objects_idx_ob_acl_destroy ON objects (ob_acl_destroy);
+
+CREATE INDEX objects_idx_ob_acl_flags ON objects (ob_acl_flags);
+
+CREATE INDEX objects_idx_ob_acl_get ON objects (ob_acl_get);
+
+CREATE INDEX objects_idx_ob_owner ON objects (ob_owner);
+
+CREATE INDEX objects_idx_ob_acl_show ON objects (ob_acl_show);
+
+CREATE INDEX objects_idx_ob_acl_store ON objects (ob_acl_store);
+
+CREATE INDEX objects_idx_ob_type ON objects (ob_type);
+
+--
+-- Table: duo
+--
+DROP TABLE IF EXISTS duo;
+
+CREATE TABLE duo (
+  du_name varchar(255) NOT NULL,
+  du_type varchar(16) NOT NULL,
+  du_key varchar(255) NOT NULL,
+  PRIMARY KEY (du_name, du_type),
+  FOREIGN KEY (du_type, du_name) REFERENCES objects(ob_type, ob_name)
+);
+
+CREATE INDEX duo_idx_du_type_du_name ON duo (du_type, du_name);
+
+COMMIT;

--- a/perl/t/general/init.t
+++ b/perl/t/general/init.t
@@ -21,12 +21,11 @@ use Util;
 
 # Use Wallet::Admin to set up the database.
 db_setup;
-my $admin = eval { Wallet::Admin->new };
+my $admin = setup_initialize();
 is ($@, '', 'Wallet::Admin creation did not die');
 ok ($admin->isa ('Wallet::Admin'), ' and returned the right class');
-is ($admin->initialize ('admin@EXAMPLE.COM'), 1,
+is ($admin->reinitialize ('admin@EXAMPLE.COM'), 1,
     ' and initialization succeeds');
-
 # Check whether the database entries that should be created were.
 my $acl = eval { Wallet::ACL->new ('ADMIN', $admin->schema) };
 is ($@, '', 'Retrieving ADMIN ACL successful');

--- a/perl/t/general/report.t
+++ b/perl/t/general/report.t
@@ -22,12 +22,13 @@ use Util;
 
 # Use Wallet::Admin to set up the database.
 db_setup;
-my $admin = eval { Wallet::Admin->new };
+my $admin = setup_initialize();
 is ($@, '', 'Wallet::Admin creation did not die');
 is ($admin->reinitialize ('admin@EXAMPLE.COM'), 1,
     'Database initialization succeeded');
 $admin->register_object ('base', 'Wallet::Object::Base');
 $admin->register_verifier ('base', 'Wallet::ACL::Base');
+
 
 # We have an empty database, so we should see no objects and one ACL.
 my $report = eval { Wallet::Report->new };
@@ -40,6 +41,7 @@ my @acls = $report->acls;
 is (scalar (@acls), 1, 'One ACL in the database');
 is ($acls[0][0], 1, ' and that is ACL ID 1');
 is ($acls[0][1], 'ADMIN', ' with the right name');
+
 
 # Check to see that we have all types that we expect.
 my @types = $report->types;
@@ -350,7 +352,6 @@ is (scalar (@acls), 1, 'There is one set of duplicate ACLs');
 is (scalar (@{ $acls[0] }), 2, ' with two members');
 is ($acls[0][0], 'fourth', ' and the first member is correct');
 is ($acls[0][1], 'third', ' and the second member is correct');
-
 # Add another line to the third ACL.  Now we match second.
 is ($server->acl_add ('third', 'base', 'foo'), 1,
     'Adding another line to the third ACL works');

--- a/perl/t/object/base.t
+++ b/perl/t/object/base.t
@@ -30,7 +30,7 @@ my $princ = 'service/test@EXAMPLE.COM';
 
 # Use Wallet::Admin to set up the database.
 db_setup;
-my $admin = eval { Wallet::Admin->new };
+my $admin = setup_initialize();
 is ($@, '', 'Database connection succeeded');
 is ($admin->reinitialize ($user), 1, 'Database initialization succeeded');
 my $schema = $admin->schema;

--- a/perl/t/object/file.t
+++ b/perl/t/object/file.t
@@ -32,7 +32,7 @@ $| = 1;
 # Use Wallet::Admin to set up the database.
 system ('rm -rf test-files') == 0 or die "cannot remove test-files\n";
 db_setup;
-my $admin = eval { Wallet::Admin->new };
+my $admin = setup_initialize();
 is ($@, '', 'Database connection succeeded');
 is ($admin->reinitialize ($user), 1, 'Database initialization succeeded');
 my $schema = $admin->schema;

--- a/perl/t/object/keytab.t
+++ b/perl/t/object/keytab.t
@@ -160,7 +160,7 @@ sub enctypes {
 # Use Wallet::Admin to set up the database.
 unlink ('krb5cc_temp', 'krb5cc_test', 'test-acl', 'test-pid');
 db_setup;
-my $admin = eval { Wallet::Admin->new };
+my $admin = setup_initialize();
 is ($@, '', 'Database connection succeeded');
 is ($admin->reinitialize ($user), 1, 'Database initialization succeeded');
 my $schema = $admin->schema;

--- a/perl/t/object/password.t
+++ b/perl/t/object/password.t
@@ -33,7 +33,7 @@ $| = 1;
 # Use Wallet::Admin to set up the database.
 system ('rm -rf test-files') == 0 or die "cannot remove test-files\n";
 db_setup;
-my $admin = eval { Wallet::Admin->new };
+my $admin = setup_initialize();
 is ($@, '', 'Database connection succeeded');
 is ($admin->reinitialize ($user), 1, 'Database initialization succeeded');
 my $schema = $admin->schema;

--- a/perl/t/verifier/nested.t
+++ b/perl/t/verifier/nested.t
@@ -31,9 +31,9 @@ my @trace = ($admin, $host, time);
 
 # Use Wallet::Admin to set up the database.
 db_setup;
-my $setup = eval { Wallet::Admin->new };
+my $setup = setup_initialize();
 is ($@, '', 'Database connection succeeded');
-is ($setup->reinitialize ($setup), 1, 'Database initialization succeeded');
+is ($setup->reinitialize ($admin), 1, 'Database initialization succeeded');
 my $schema = $setup->schema;
 
 # Create a few ACLs for later testing.

--- a/server/wallet-backend.in
+++ b/server/wallet-backend.in
@@ -154,6 +154,20 @@ sub command {
         } elsif ($action eq 'create') {
             check_args (1, 1, [], @args);
             $server->acl_create (@args) or failure ($server->error, @_);
+        } elsif ($action eq 'comment') {
+            check_args (1, 2, [2], @args);
+            if (@args > 1) {
+                $server->acl_comment (@args) or failure ($server->error, @_);
+            } else {
+                my $output = $server->acl_comment (@args);
+                if (defined $output) {
+                    print $output, "\n";
+                } elsif (not $server->error) {
+                    print "No comment set\n";
+                } else {
+                    failure ($server->error, @_);
+                }
+            }
         } elsif ($action eq 'destroy') {
             check_args (1, 1, [], @args);
             $server->acl_destroy (@args) or failure ($server->error, @_);
@@ -427,6 +441,15 @@ either the name of an ACL or its numeric identifier.
 Check whether an ACL with the ID <id> already exists.  If it does, prints
 C<yes>; if not, prints C<no>.
 
+=item acl comment <id> [<comment>]
+
+If <comment> is not given, displays the current comment for the ACL
+identified by <id> and <name>, or C<No comment set> if none is set.
+
+If <comment> is given, sets the comment on the ACL identified by
+<id> to <comment>.  If <comment> is the empty string, clears
+the comment.
+
 =item acl create <name>
 
 Create a new, empty ACL with name <name>.  When setting an ACL on an
@@ -444,7 +467,7 @@ be destroyed.
 =item acl history <id>
 
 Display the history of the ACL <id>.  Each change to the ACL (not
-including changes to the name of the ACL) will be represented by two
+including changes to the name or comment of the ACL) will be represented by two
 lines.  The first line will have a timestamp of the change followed by a
 description of the change, and the second line will give the user who made
 the change and the host from which the change was made.
@@ -479,7 +502,7 @@ the C<ADMIN> ACL.
 
 =item acl show <id>
 
-Display the name, numeric ID, and entries of the ACL <id>.
+Display the name, numeric ID, comment, and entries of the ACL <id>.
 
 =item autocreate <type> <name>
 


### PR DESCRIPTION
These are the changes in this pull request:

* Add the "comment" field to ACLs. Interface is the same as for objects:

        wallet acl comment group/access "This is a comment"

  Output looks like this:

        Members of ACL group/spdb (id: 7338) are:
          krb5 host/lemon-uat1.example.com@EXAMPLE.COM
          krb5 host/lemon-uat2.example.com@EXAMPLE.COM
          krb5 host/lemon1.example.com@EXAMPLE.COM
          krb5 host/lemon2.example.com@EXAMPLE.COM
          netdb-root lemon-uat1.example.com
          netdb-root lemon-uat2.example.com
          netdb-root lemon1.example.com
          netdb-root lemon2.example.com
        comment: This is a comment

* In the output of an ACLs history add secondary sort on the history entries' primary key in the history table. This is to handle cases where several entries have the identical create time.

* Remove trailing white-space at the end of some of the lines of output of the "show" commands.

* Force the timezone to be 'local' in DateTime->from_epoch function calls.

* Re-order table drops in Wallet::Admin::destroy to take into account table dependencies.

* In Wallet::Report make sure that acl memberships are sorted to fix a bug in the acl_duplicates method.

* Add a 1-byte character set for the MySQL .sql file. Newer MySQL server releases default to a 4-byte character set when creating tables. Wallet  sets indices on some 255-byte fields which, with a 4-byte character set, exceeds the maximum index length that MySQL supports.

* Fix some tests to be more flexible when running "make check" against MySQL or PostgreSQL. MySQL and PostgreSQL can leave "holes" in the primary keys used if a record insert fails due to a constraint violation. Thus, the primary key for some ACLs in the test suite will differ when running "make check" against SQLite versus running "make check" against MySQL.

* Turn off version checking when doing initial set up of a database. Otherwise DBIx::Class::Schema complains about an unversioned database.

* Fix bug in t/general/admin.t test suite where some tests would fail if run with a backend other than SQLite.